### PR TITLE
Cadastrar tipo de unidade com sucesso e validacao para presença dos parametros

### DIFF
--- a/app/controllers/unit_types_controller.rb
+++ b/app/controllers/unit_types_controller.rb
@@ -1,0 +1,25 @@
+class UnitTypesController < ApplicationController
+  def new
+    @unit_type = UnitType.new
+  end
+
+  def create
+    @unit_type = UnitType.new(receive_params)
+    if @unit_type.save
+      redirect_to @unit_type, notice: t('notices.unit_type.created')
+    else
+      flash.now[:alert] = t('alerts.unit_type.not_created')
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def show
+    @unit_type = UnitType.find(params[:id])
+  end
+
+  private
+
+  def receive_params
+    params.require(:unit_type).permit(:description, :metreage)
+  end
+end

--- a/app/models/unit_type.rb
+++ b/app/models/unit_type.rb
@@ -1,3 +1,3 @@
 class UnitType < ApplicationRecord
-  belongs_to :tower
+  validates :description, :metreage, presence: true
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,6 +12,8 @@
 
   <body>
     <div class="container">
+      <%= notice %>
+      <%= alert %>
       <%= yield %>
     </div>
   </body>

--- a/app/views/shared/_errors.html.erb
+++ b/app/views/shared/_errors.html.erb
@@ -1,0 +1,14 @@
+<% if model.errors.any? %>
+  <div class="alert alert-secondary pb-0" role="alert">
+    <h4 class="alert-heading">
+      <p>Verifique os erros abaixo</p>
+    </h4>
+    <div class="my-0">
+      <ul>
+        <% model.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  </div>
+<% end %>

--- a/app/views/unit_types/new.html.erb
+++ b/app/views/unit_types/new.html.erb
@@ -1,0 +1,19 @@
+<h1>Cadastrar um novo tipo de unidade</h1>
+
+<%=  render 'shared/errors', model: @unit_type %>
+
+<%= form_with(model: @unit_type) do |f| %>
+  <div>
+    <%= f.label :description %>
+    <%= f.text_area :description%>
+  </div>
+
+  <div>
+    <%= f.label :metreage %>
+    <%= f.number_field :metreage%>
+  </div>
+
+  <div>
+    <%= f.submit 'Cadastrar' %>
+  </div>
+<% end %>

--- a/app/views/unit_types/show.html.erb
+++ b/app/views/unit_types/show.html.erb
@@ -1,0 +1,10 @@
+<h1>Tipo de unidade</h1>
+
+
+<div>
+  Descrição: <%= @unit_type.description %>
+</div>
+
+<div>
+  Metragem: <%= @unit_type.metreage%>m²
+</div>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -29,7 +29,7 @@ Rails.application.configure do
   config.cache_store = :null_store
 
   # Render exception templates for rescuable exceptions and raise for other exceptions.
-  config.action_dispatch.show_exceptions = :rescuable
+  config.action_dispatch.show_exceptions = :none
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false

--- a/config/initializers/locale.rb
+++ b/config/initializers/locale.rb
@@ -1,0 +1,8 @@
+# Where the I18n library should search for translation files
+I18n.load_path += Dir[Rails.root.join('lib', 'locale', '*.{rb,yml}')]
+
+# Permitted locales available for the application
+I18n.available_locales = [:en, :'pt-BR']
+
+# Set default locale to something other than :en
+I18n.default_locale = :'pt-BR'

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -1,0 +1,225 @@
+---
+pt-BR:
+  activerecord:
+    errors:
+      messages:
+        record_invalid: 'A validação falhou: %{errors}'
+        restrict_dependent_destroy:
+          has_one: Não é possível excluir o registro pois existe um %{record} dependente
+          has_many: Não é possível excluir o registro pois existem %{record} dependentes
+  date:
+    abbr_day_names:
+    - dom
+    - seg
+    - ter
+    - qua
+    - qui
+    - sex
+    - sáb
+    abbr_month_names:
+    -
+    - jan
+    - fev
+    - mar
+    - abr
+    - mai
+    - jun
+    - jul
+    - ago
+    - set
+    - out
+    - nov
+    - dez
+    day_names:
+    - domingo
+    - segunda-feira
+    - terça-feira
+    - quarta-feira
+    - quinta-feira
+    - sexta-feira
+    - sábado
+    formats:
+      default: "%d/%m/%Y"
+      long: "%d de %B de %Y"
+      short: "%d de %B"
+    month_names:
+    -
+    - janeiro
+    - fevereiro
+    - março
+    - abril
+    - maio
+    - junho
+    - julho
+    - agosto
+    - setembro
+    - outubro
+    - novembro
+    - dezembro
+    order:
+    - :day
+    - :month
+    - :year
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: aproximadamente %{count} hora
+        other: aproximadamente %{count} horas
+      about_x_months:
+        one: aproximadamente %{count} mês
+        other: aproximadamente %{count} meses
+      about_x_years:
+        one: aproximadamente %{count} ano
+        other: aproximadamente %{count} anos
+      almost_x_years:
+        one: quase %{count} ano
+        other: quase %{count} anos
+      half_a_minute: meio minuto
+      less_than_x_seconds:
+        one: menos de %{count} segundo
+        other: menos de %{count} segundos
+      less_than_x_minutes:
+        one: menos de um minuto
+        other: menos de %{count} minutos
+      over_x_years:
+        one: mais de %{count} ano
+        other: mais de %{count} anos
+      x_seconds:
+        one: "%{count} segundo"
+        other: "%{count} segundos"
+      x_minutes:
+        one: "%{count} minuto"
+        other: "%{count} minutos"
+      x_days:
+        one: "%{count} dia"
+        other: "%{count} dias"
+      x_months:
+        one: "%{count} mês"
+        other: "%{count} meses"
+      x_years:
+        one: "%{count} ano"
+        other: "%{count} anos"
+    prompts:
+      second: Segundo
+      minute: Minuto
+      hour: Hora
+      day: Dia
+      month: Mês
+      year: Ano
+  errors:
+    format: "%{attribute} %{message}"
+    messages:
+      accepted: deve ser aceito
+      blank: não pode ficar em branco
+      confirmation: não é igual a %{attribute}
+      empty: não pode ficar vazio
+      equal_to: deve ser igual a %{count}
+      even: deve ser par
+      exclusion: não está disponível
+      greater_than: deve ser maior que %{count}
+      greater_than_or_equal_to: deve ser maior ou igual a %{count}
+      in: deve estar em %{count}
+      inclusion: não está incluído na lista
+      invalid: não é válido
+      less_than: deve ser menor que %{count}
+      less_than_or_equal_to: deve ser menor ou igual a %{count}
+      model_invalid: 'A validação falhou: %{errors}'
+      not_a_number: não é um número
+      not_an_integer: não é um número inteiro
+      odd: deve ser ímpar
+      other_than: deve ser diferente de %{count}
+      present: deve ficar em branco
+      required: é obrigatório(a)
+      taken: já está em uso
+      too_long:
+        one: 'é muito longo (máximo: %{count} caracter)'
+        other: 'é muito longo (máximo: %{count} caracteres)'
+      too_short:
+        one: 'é muito curto (mínimo: %{count} caracter)'
+        other: 'é muito curto (mínimo: %{count} caracteres)'
+      wrong_length:
+        one: não possui o tamanho esperado (%{count} caracter)
+        other: não possui o tamanho esperado (%{count} caracteres)
+    template:
+      body: 'Por favor, verifique o(s) seguinte(s) campo(s):'
+      header:
+        one: 'Não foi possível gravar %{model}: %{count} erro'
+        other: 'Não foi possível gravar %{model}: %{count} erros'
+  helpers:
+    select:
+      prompt: Por favor selecione
+    submit:
+      create: Criar %{model}
+      submit: Salvar %{model}
+      update: Atualizar %{model}
+  number:
+    currency:
+      format:
+        delimiter: "."
+        format: "%u %n"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: R$
+    format:
+      delimiter: "."
+      precision: 3
+      round_mode: default
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion:
+            one: bilhão
+            other: bilhões
+          million:
+            one: milhão
+            other: milhões
+          quadrillion:
+            one: quatrilhão
+            other: quatrilhões
+          thousand: mil
+          trillion:
+            one: trilhão
+            other: trilhões
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: "."
+        format: "%n%"
+    precision:
+      format:
+        delimiter: "."
+  support:
+    array:
+      last_word_connector: " e "
+      two_words_connector: " e "
+      words_connector: ", "
+  time:
+    am: am
+    formats:
+      default: "%a, %d de %B de %Y, %H:%M:%S %z"
+      long: "%d de %B de %Y, %H:%M"
+      short: "%d de %B, %H:%M"
+    pm: pm

--- a/config/locales/unit_type.pt-BR.yml
+++ b/config/locales/unit_type.pt-BR.yml
@@ -1,0 +1,18 @@
+pt-BR:
+  notices:
+    unit_type:
+      created: 'Tipo de unidade cadastrado com sucesso'
+  alerts:    
+    unit_type:
+      not_created: 'Erro ao cadastrar tipo de unidade'
+  description: 'Descrição'
+  metreage: 'Metragem'
+  activerecord:
+    models:
+      unit_type:
+      one: 'Tipo de unidade'
+      other: 'Tipo de unidades'
+    attributes:
+      unit_type:
+        description: 'Descrição'
+        metreage: 'Metragem'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,6 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   resources :condos, only: [:new, :create, :show]
+  resources :unit_types, only: [:new, :create, :show]
   root to: "home#index"
 end

--- a/db/migrate/20240625192819_remove_tower_id_from_unit_types.rb
+++ b/db/migrate/20240625192819_remove_tower_id_from_unit_types.rb
@@ -1,0 +1,5 @@
+class RemoveTowerIdFromUnitTypes < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :unit_types, :tower_id, :integer
+  end
+end

--- a/db/migrate/20240625200919_change_metreage_to_decimal.rb
+++ b/db/migrate/20240625200919_change_metreage_to_decimal.rb
@@ -1,0 +1,5 @@
+class ChangeMetreageToDecimal < ActiveRecord::Migration[7.1]
+  def change
+    change_column :unit_types, :metreage, :decimal, precision: 10, scale: 2
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_25_175543) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_25_200919) do
   create_table "addresses", force: :cascade do |t|
     t.string "public_place"
     t.string "number"
@@ -67,11 +67,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_25_175543) do
 
   create_table "unit_types", force: :cascade do |t|
     t.text "description"
-    t.integer "metreage"
-    t.integer "tower_id", null: false
+    t.decimal "metreage", precision: 10, scale: 2
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["tower_id"], name: "index_unit_types_on_tower_id"
   end
 
   create_table "units", force: :cascade do |t|
@@ -85,6 +83,5 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_25_175543) do
   add_foreign_key "common_areas", "condos", column: "condominium_id"
   add_foreign_key "condos", "addresses"
   add_foreign_key "towers", "condos", column: "condominium_id"
-  add_foreign_key "unit_types", "towers"
   add_foreign_key "units", "unit_types"
 end

--- a/spec/system/unit_types/user_visit_unit_type_page_spec.rb
+++ b/spec/system/unit_types/user_visit_unit_type_page_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+describe 'User register new unit type' do
+  it 'sucessfully' do
+    visit new_unit_type_path
+
+    fill_in 'Descrição',	with: 'Apartamento de 2 quartos'
+    fill_in 'Metragem',	with: '50'
+    click_on 'Cadastrar'
+
+    expect(page).to have_content('Tipo de unidade cadastrado com sucesso')
+    expect(current_path).to eq unit_type_path(UnitType.last)
+    expect(page).to have_content('Descrição: Apartamento de 2 quartos')
+    expect(page).to have_content('Metragem: 50.0m²')
+  end
+
+  it 'with missing parameters' do
+    visit new_unit_type_path
+
+    click_on 'Cadastrar'
+
+    expect(page).to have_content('Erro ao cadastrar tipo de unidade')
+    expect(page).to have_content('Descrição não pode ficar em branco')
+    expect(page).to have_content('Metragem não pode ficar em branco')
+  end
+
+  xit 'from condo page' do
+  end
+end


### PR DESCRIPTION
Usuario cadastra tipo de unidade com sucesso.
Validacao para presença dos campos obrigatorios

Removido referencia a torre do tipo de unidade
Alterado tipo da variavel metragem, de inteiro para decimal

Configurado I18n
Criado um shared para erros, 'shared/errors'

#2 