### PR TITLE
Adicionar área comum à barra de navegação

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -46,6 +46,10 @@
             <li class="nav-item">
               <a class="nav-link custom-element text-white" href="#" data-bs-toggle="modal" data-bs-target="#condoSelectPopupForTowers">Criar Torre</a>
             </li>
+            <li><hr class="nav-divider m-0"></li>
+            <li class="nav-item">
+              <a class="nav-link custom-element text-white" href="#" data-bs-toggle="modal" data-bs-target="#condoSelectPopupForCommonAreas">Criar Área Comum</a>
+            </li>
           </ul>
         </div>
       </div>
@@ -91,6 +95,31 @@
             <% Condo.all.each do |condo| %>
               <div class='col'>
                 <%= button_to condo.name, new_condo_unit_type_path(condo), method: :get, class:'btn btn-dark', data: { turbo: false }%>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Fechar</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal fade" id="condoSelectPopupForCommonAreas" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1" aria-labelledby="condoSelectPopupLabel" aria-hidden="true" >
+  <div class="modal-dialog modal-dialog-scrollable">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h1 class="modal-title fs-5" id="condoSelectPopupLabel">Selecione o Condominio</h1>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div class='container text-center'>
+          <div class='row'>
+            <% Condo.all.each do |condo| %>
+              <div class='col'>
+                <%= button_to condo.name, new_condo_common_area_path(condo), method: :get, class:'btn btn-dark', data: { turbo: false }%>
               </div>
             <% end %>
           </div>

--- a/app/views/unit_types/edit.html.erb
+++ b/app/views/unit_types/edit.html.erb
@@ -1,4 +1,4 @@
-<h1>Editar um novo tipo de unidade</h1>
+<h1>Editar tipo de unidade</h1>
 
 <%=  render 'shared/errors', model: @unit_type %>
 

--- a/spec/system/common_area/manager_registers_new_common_area_spec.rb
+++ b/spec/system/common_area/manager_registers_new_common_area_spec.rb
@@ -1,6 +1,23 @@
 require 'rails_helper'
 
 describe 'Manager registers new common area' do
+  it 'and access from nav bar' do
+    manager = create(:manager)
+    condo = create(:condo, name: 'Condomínio dos rubinhos')
+
+    login_as(manager, scope: :manager)
+    visit root_path
+    within 'nav' do
+      click_on id: 'side-menu'
+      click_on 'Criar Área Comum'
+    end
+    within '#condoSelectPopupForCommonAreas' do
+      click_on 'Condomínio dos rubinhos'
+    end
+
+    expect(current_path).to eq new_condo_common_area_path(condo)
+  end
+
   it 'successfully' do
     manager = create(:manager)
     condo = create(:condo)


### PR DESCRIPTION
### Introdução
O administrador pode criar áreas comuns a partir do menu lateral, para acelerar a navegação.

### Objetivo
Permitir que seja possível acessar a criação de áreas comuns através da barra lateral

![Common_areas_nav_bar](https://github.com/TreinaDev/condominions/assets/88754301/40fa3199-4e70-4f05-aae5-f79fee87b665)

Resolve #45 

Refatora o texto da view de edição de tipos de unidade