### PR TITLE
API - Listar tipos de unidade

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@
 
 `GET /api/v1/condos`
 
-<p align="justify">Retorna todos os condomínios com o id, nome, cidade e estado de cada um, ou retorna um vetor vazio caso não exista nenhum condomínio cadastrado.</p>
+<p align="justify">Retorna todos os condomínios com o id, nome, cidade e estado de cada um.</p>
 
 Exemplo de resposta:
 ```
@@ -111,7 +111,9 @@ Exemplo de resposta:
 
 `GET /api/v1/condos/{id}`
 
-<p align="justify">Retorna os detalhes de um condomínio com o nome, cnpj, logradouro, número, bairro, cidade, estado e cep de cada um. Retorna erro 404 caso não exista um condomínio cadastrado com esse id.</p>
+<p align="justify">Retorna os detalhes de um condomínio com o nome, cnpj, logradouro, número, bairro, cidade, estado e cep de cada um.
+
+Retorna erro 404 caso não exista um condomínio cadastrado com esse id.</p>
 
 Exemplo de resposta:
 ```
@@ -127,6 +129,46 @@ Exemplo de resposta:
     "zip": "69911-520"
   }
 }
+```
+
+### Endpoint Listar Tipos de Unidade
+
+`GET /api/v1/condos/{id}/unit_types`
+
+<p align="justify">Retorna a lista de tipos de unidade registradas em um condomínio e os ids da unidades vinculadas a ele.
+
+Retorna 404 caso não exista um condomínio com o id informado</p>
+
+Exemplo de resposta:
+```
+[
+  {
+    "id": 1,
+    "description": "Apartamento grande",
+    "metreage": "100.0",
+    "fraction": "4.0",
+    "unit_ids": [
+      1,
+      2,
+      3,
+      4,
+      6,
+      9
+    ]
+  },
+  {
+    "id": 2,
+    "description": "Apartamento médio",
+    "metreage": "70.2",
+    "fraction": "2.5",
+    "unit_ids": [
+      5,
+      7,
+      8,
+      10
+    ]
+  }
+]
 ```
 
 <p align="right">(<a href="#readme-top">voltar ao topo</a>)</p>

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -2,9 +2,14 @@ module Api
   module V1
     class ApiController < ActionController::API
       rescue_from ActiveRecord::ActiveRecordError, with: :internal_server_error
+      rescue_from ActiveRecord::RecordNotFound, with: :not_found
 
       def internal_server_error
         render body: nil, status: :internal_server_error
+      end
+
+      def not_found
+        render body: nil, status: :not_found
       end
     end
   end

--- a/app/controllers/api/v1/unit_types_controller.rb
+++ b/app/controllers/api/v1/unit_types_controller.rb
@@ -1,0 +1,14 @@
+module Api
+  module V1
+    class UnitTypesController < Api::V1::ApiController
+      def index
+        return render body: nil, status: :not_found if Condo.find_by(id: params[:condo_id]).nil?
+
+        render status: :ok,
+               json: UnitType.where(condo_id: params[:condo_id])
+                             .as_json(only: %i[id description metreage fraction],
+                                      methods: [:unit_ids])
+      end
+    end
+  end
+end

--- a/app/models/unit_type.rb
+++ b/app/models/unit_type.rb
@@ -12,4 +12,8 @@ class UnitType < ApplicationRecord
   def fraction_to_percentage
     "#{fraction}%"
   end
+
+  def unit_ids
+    units.pluck :id
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,8 +5,8 @@ Rails.application.routes.draw do
   devise_for :managers
   devise_for :residents
   resources :managers, only: [:new, :create]
-  resources :residents, only: [:new, :create] do 
-    get 'find_towers', on: :collection 
+  resources :residents, only: [:new, :create] do
+    get 'find_towers', on: :collection
   end
   resources :common_areas, only: [:show, :edit, :update]
 
@@ -30,7 +30,9 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      resources :condos, only: [:index, :show]
+      resources :condos, only: [:index, :show] do
+        resources :unit_types, only: [:index]
+      end
     end
   end
 end

--- a/spec/models/unit_type_spec.rb
+++ b/spec/models/unit_type_spec.rb
@@ -1,6 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe UnitType, type: :model do
+  context '#unit_ids' do
+    it "return ids from unit type's units" do
+      unit_type = build :unit_type
+      unit = create(:unit, unit_type:)
+
+      expect(unit_type.unit_ids).to include unit.id
+    end
+  end
+
   context '#valid?' do
     it 'missing params' do
       unit_type = UnitType.new(description: '', metreage: '', fraction: '')

--- a/spec/requests/apis/unit_type_spec.rb
+++ b/spec/requests/apis/unit_type_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 describe 'Unit Type API' do
   context 'GET /api/v1/condos/{id}/unit_types' do
     it 'successfully' do
-      first_condo = create :Condo
-      second_condo = create :Condo
+      first_condo = create :condo
+      second_condo = create :condo
 
       first_unit_type = create :unit_type,
                                description: 'Apartamento de 1 quarto',
@@ -61,22 +61,24 @@ describe 'Unit Type API' do
       expect(response).to have_http_status :ok
       expect(response.parsed_body[0]['created_at']).not_to be_present
       expect(response.parsed_body[0]['updated_at']).not_to be_present
-      expect(response.parsed_body.size).to eq 2
+      expect(response.parsed_body.count).to eq 2
 
       expect(response.parsed_body[0]['id']).to eq 1
       expect(response.parsed_body[0]['description']).to eq 'Apartamento de 1 quarto'
-      expect(response.parsed_body[0]['metreage']).to eq 50.55
-      expect(response.parsed_body[0]['fraction']).to eq 2
-      expect(response.parsed_body[0]['unit_ids'].size).to eq 4
+      expect(response.parsed_body[0]['metreage']).to eq '50.55'
+      expect(response.parsed_body[0]['fraction']).to eq '2.0'
+      expect(response.parsed_body[0]['unit_ids'].count).to eq 4
 
       expect(response.parsed_body[1]['id']).to eq 3
       expect(response.parsed_body[1]['description']).to eq 'Apartamento de 3 quartos'
-      expect(response.parsed_body[1]['metreage']).to eq 90
-      expect(response.parsed_body[1]['fraction']).to eq 4
-      expect(response.parsed_body[1]['unit_ids'].size).to eq 6
+      expect(response.parsed_body[1]['metreage']).to eq '90.0'
+      expect(response.parsed_body[1]['fraction']).to eq '4.0'
+      expect(response.parsed_body[1]['unit_ids'].count).to eq 6
     end
 
     it "and there's no unit types" do
+      create :condo
+
       get '/api/v1/condos/1/unit_types'
 
       expect(response).to have_http_status :ok
@@ -90,11 +92,12 @@ describe 'Unit Type API' do
     end
 
     it "and fail if there's an internal server error" do
+      create :condo
       allow(UnitType).to receive(:all).and_raise ActiveRecord::ActiveRecordError
 
       get '/api/v1/condos/1/unit_types'
 
-      expect(response.status).to eq :internal_server_error
+      expect(response).to have_http_status :internal_server_error
     end
   end
 end

--- a/spec/requests/apis/unit_type_spec.rb
+++ b/spec/requests/apis/unit_type_spec.rb
@@ -1,0 +1,100 @@
+require 'rails_helper'
+
+describe 'Unit Type API' do
+  context 'GET /api/v1/condos/{id}/unit_types' do
+    it 'successfully' do
+      first_condo = create :Condo
+      second_condo = create :Condo
+
+      first_unit_type = create :unit_type,
+                               description: 'Apartamento de 1 quarto',
+                               metreage: 50.55,
+                               fraction: 2,
+                               condo: first_condo
+
+      second_unit_type = create :unit_type,
+                                description: 'Apartamento de 2 quartos',
+                                condo: second_condo
+
+      third_unit_type = create :unit_type,
+                               description: 'Apartamento de 3 quartos',
+                               metreage: 90,
+                               fraction: 4,
+                               condo: first_condo
+
+      first_tower = create :tower, floor_quantity: 2,
+                                   units_per_floor: 2,
+                                   condo: first_condo
+
+      second_tower = create :tower,
+                            floor_quantity: 3,
+                            units_per_floor: 2,
+                            condo: second_condo
+
+      third_tower = create :tower,
+                           floor_quantity: 2,
+                           units_per_floor: 3,
+                           condo: first_condo
+
+      first_tower.generate_floors
+      second_tower.generate_floors
+      third_tower.generate_floors
+
+      first_tower.floors.each do |floor|
+        floor.units[0].update unit_type: first_unit_type
+        floor.units[1].update unit_type: third_unit_type
+      end
+
+      second_tower.floors.each do |floor|
+        floor.units[0].update unit_type: second_unit_type
+        floor.units[1].update unit_type: second_unit_type
+      end
+
+      third_tower.floors.each do |floor|
+        floor.units[0].update unit_type: third_unit_type
+        floor.units[1].update unit_type: third_unit_type
+        floor.units[2].update unit_type: first_unit_type
+      end
+
+      get '/api/v1/condos/1/unit_types'
+
+      expect(response).to have_http_status :ok
+      expect(response.parsed_body[0]['created_at']).not_to be_present
+      expect(response.parsed_body[0]['updated_at']).not_to be_present
+      expect(response.parsed_body.size).to eq 2
+
+      expect(response.parsed_body[0]['id']).to eq 1
+      expect(response.parsed_body[0]['description']).to eq 'Apartamento de 1 quarto'
+      expect(response.parsed_body[0]['metreage']).to eq 50.55
+      expect(response.parsed_body[0]['fraction']).to eq 2
+      expect(response.parsed_body[0]['unit_ids'].size).to eq 4
+
+      expect(response.parsed_body[1]['id']).to eq 3
+      expect(response.parsed_body[1]['description']).to eq 'Apartamento de 3 quartos'
+      expect(response.parsed_body[1]['metreage']).to eq 90
+      expect(response.parsed_body[1]['fraction']).to eq 4
+      expect(response.parsed_body[1]['unit_ids'].size).to eq 6
+    end
+
+    it "and there's no unit types" do
+      get '/api/v1/condos/1/unit_types'
+
+      expect(response).to have_http_status :ok
+      expect(response.parsed_body).to be_empty
+    end
+
+    it 'and returns not found if condo is not found' do
+      get '/api/v1/condos/999999999/unit_types'
+
+      expect(response).to have_http_status :not_found
+    end
+
+    it "and fail if there's an internal server error" do
+      allow(UnitType).to receive(:all).and_raise ActiveRecord::ActiveRecordError
+
+      get '/api/v1/condos/1/unit_types'
+
+      expect(response.status).to eq :internal_server_error
+    end
+  end
+end


### PR DESCRIPTION
### Introdução
Sistemas externos agora podem requisitar a API condominions e obter uma lista de tipos de unidade. Também é retornado os ids das unidades associadas cadastradas no sistema para fins de identificação e quantificação.

### Objetivo
Permitir que a aplicação [PagueAluguel](https://github.com/TreinaDev/pague-aluguel) consiga obter a lista de tipos de unidades desta aplicação, sabendo com quais unidades eles estão associados.

### Endpoint
`GET /api/v1/condos/{id}/unit_types`

Retorna todos os tipos de unidades com o `id`, descrição, metragem, fração ideal e ids de unidades associadas de cada um.

Retorna erro um vetor vazio caso não existam tipos de unidades cadastradas para o condomínio informado.

Retorna erro `404` caso o condomínio informado não esteja cadastrado.

Exemplo de Resposta:

```
[
  {
    "id": 1,
    "description": "Apartamento grande",
    "metreage": "100.0",
    "fraction": "4.0",
    "unit_ids": [
      1,
      2,
      3,
      4,
      6,
      9
    ]
  },
  {
    "id": 2,
    "description": "Apartamento médio",
    "metreage": "70.2",
    "fraction": "2.5",
    "unit_ids": [
      5,
      7,
      8,
      10
    ]
  }
]
```

Foram implementados testes de requisição de API e teste unitário.

Resolve a issue #50 