### PR TITLE
Api-Validação do CPF do proprietário

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,9 @@ Exemplos de resposta:
 }
 ```
 
+<p align="justify">OBS: Caso não exista morador com o CPF informado, será retornado o erro 404 (not found) e o json nos padrões anteriores:</p>
+
+
 ```
 {
   "profile": "inexistent",
@@ -200,7 +203,7 @@ Exemplos de resposta:
 }
 ```
 
-<p align="justify">OBS: Caso o CPF seja inválido, será retornado o erro 412 (precondition failed) e o json com o campo 'error'</p>
+<p align="justify">OBS: Caso o CPF seja inválido, será retornado o erro 412 (precondition failed) e o json com o campo 'error':</p>
 
 ```
 {

--- a/README.md
+++ b/README.md
@@ -129,6 +129,42 @@ Exemplo de resposta:
 }
 ```
 
+### Endpoint de Validação por CPF
+
+`/api/v1/check_registration_number?registration_number={CPF}`
+
+<p align="justify">Retorna a confirmação se o CPF informado pertence a um usuário da aplicação Condomínions, ainda retorna o perfil de usuário e o id de sua unidade</p>
+
+Exemplos de resposta:
+```
+{
+  "profile": "owner",
+  "unit_id": "1"
+}
+```
+
+```
+{
+  "profile": "tenant",
+  "unit_id": "10"
+}
+```
+
+```
+{
+  "profile": "inexistent",
+  "unit_id": "nil"
+}
+```
+
+<p align="justify">OBS: Caso o CPF seja inválido, será retornado o erro 412 (precondition failed) e o json com o campo 'error'</p>
+
+```
+{
+  "error": "invalid registration number"
+}
+```
+
 <p align="right">(<a href="#readme-top">voltar ao topo</a>)</p>
 
 <!-- GETTING STARTED -->

--- a/app/controllers/api/v1/residents_controller.rb
+++ b/app/controllers/api/v1/residents_controller.rb
@@ -1,0 +1,19 @@
+module Api
+  module V1
+    class ResidentsController < Api::V1::ApiController
+      def check_registration_number
+        resident = Resident.find_by(registration_number: params[:registration_number])
+        return render status: :ok, json: { resident_type: 'inexistent' } if resident.nil?
+
+        render status: :ok, json: resident.as_json(only: [:resident_type])
+      end
+    end
+  end
+end
+
+#render status: :ok, json: Condo.all.as_json(only: %i[id name],
+#                                                    methods: %i[city state])
+
+
+#render status: :ok, json: Condo.all.as_json(only: %i[id name],
+#                                                    methods: %i[city state])

--- a/app/controllers/api/v1/residents_controller.rb
+++ b/app/controllers/api/v1/residents_controller.rb
@@ -3,6 +3,11 @@ module Api
     class ResidentsController < Api::V1::ApiController
       def check_registration_number
         resident = Resident.find_by(registration_number: params[:registration_number])
+
+        unless CPF.valid? params[:registration_number]
+          return render status: :precondition_failed, json: { error: 'invalid registration number' }
+        end
+
         return render status: :ok, json: { resident_type: 'inexistent' } if resident.nil?
 
         render status: :ok, json: resident.as_json(only: [:resident_type])
@@ -10,10 +15,3 @@ module Api
     end
   end
 end
-
-#render status: :ok, json: Condo.all.as_json(only: %i[id name],
-#                                                    methods: %i[city state])
-
-
-#render status: :ok, json: Condo.all.as_json(only: %i[id name],
-#                                                    methods: %i[city state])

--- a/app/controllers/api/v1/residents_controller.rb
+++ b/app/controllers/api/v1/residents_controller.rb
@@ -2,13 +2,12 @@ module Api
   module V1
     class ResidentsController < Api::V1::ApiController
       def check_registration_number
-        resident = Resident.find_by(registration_number: params[:registration_number])
-
         unless CPF.valid? params[:registration_number]
           return render status: :precondition_failed, json: { error: 'invalid registration number' }
         end
 
-        return render status: :ok, json: { resident_type: 'inexistent', unit_id: 'nil' } if resident.nil?
+        resident = Resident.find_by(registration_number: params[:registration_number])
+        return render status: :not_found, json: { resident_type: 'inexistent', unit_id: 'nil' } if resident.nil?
 
         render status: :ok, json: resident.as_json(only: %i[resident_type unit_id])
       end

--- a/app/controllers/api/v1/residents_controller.rb
+++ b/app/controllers/api/v1/residents_controller.rb
@@ -8,9 +8,9 @@ module Api
           return render status: :precondition_failed, json: { error: 'invalid registration number' }
         end
 
-        return render status: :ok, json: { resident_type: 'inexistent' } if resident.nil?
+        return render status: :ok, json: { resident_type: 'inexistent', unit_id: 'nil' } if resident.nil?
 
-        render status: :ok, json: resident.as_json(only: [:resident_type])
+        render status: :ok, json: resident.as_json(only: %i[resident_type unit_id])
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :condos, only: [:index, :show]
+      get 'check_registration_number', to: 'residents#check_registration_number'
     end
   end
 end

--- a/spec/requests/apis/resident_spec.rb
+++ b/spec/requests/apis/resident_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+describe 'Resident API' do
+  context 'GET /api/v1/check_registration_number?' do
+    it 'successfully and is an owner' do
+      resident = create(:resident, registration_number: '076.550.640-83', resident_type: :owner)
+
+      get "/api/v1/check_registration_number?registration_number=#{resident.registration_number}"
+
+      expect(response).to have_http_status :ok
+      expect(response.content_type).to include 'application/json'
+      expect(response.parsed_body['resident_type']).to eq 'owner'
+    end
+
+    it 'successfully and is a tenant' do
+      resident = create(:resident, registration_number: '076.550.640-83', resident_type: :tenant)
+
+      get "/api/v1/check_registration_number?registration_number=#{resident.registration_number}"
+
+      expect(response).to have_http_status :ok
+      expect(response.content_type).to include 'application/json'
+      expect(response.parsed_body['resident_type']).to eq 'tenant'
+    end
+
+    it "successfully and there's no match on the database" do
+      registration_number = '076.550.640-83'
+      get "/api/v1/check_registration_number?registration_number=#{registration_number}"
+
+      expect(response).to have_http_status :ok
+      expect(response.content_type).to include 'application/json'
+      expect(response.parsed_body['resident_type']).to eq 'inexistent'
+    end
+
+    it "and fail if there's an internal server error" do
+    end
+  end
+end

--- a/spec/requests/apis/resident_spec.rb
+++ b/spec/requests/apis/resident_spec.rb
@@ -25,18 +25,16 @@ describe 'Resident API' do
     end
 
     it "successfully and there's no match on the database" do
-      registration_number = '076.550.640-83'
-      get "/api/v1/check_registration_number?registration_number=#{registration_number}"
+      get '/api/v1/check_registration_number?registration_number=076.550.640-83'
 
-      expect(response).to have_http_status :ok
+      expect(response).to have_http_status :not_found
       expect(response.content_type).to include 'application/json'
       expect(response.parsed_body['resident_type']).to eq 'inexistent'
       expect(response.parsed_body['unit_id']).to eq 'nil'
     end
 
     it 'and fail if the registration number is invalid' do
-      registration_number = '111.111.111-11'
-      get "/api/v1/check_registration_number?registration_number=#{registration_number}"
+      get '/api/v1/check_registration_number?registration_number=111.111.111-11'
 
       expect(response).to have_http_status :precondition_failed
       expect(response.content_type).to include 'application/json'

--- a/spec/requests/apis/resident_spec.rb
+++ b/spec/requests/apis/resident_spec.rb
@@ -10,6 +10,7 @@ describe 'Resident API' do
       expect(response).to have_http_status :ok
       expect(response.content_type).to include 'application/json'
       expect(response.parsed_body['resident_type']).to eq 'owner'
+      expect(response.parsed_body['unit_id']).to eq resident.unit_id
     end
 
     it 'successfully and is a tenant' do
@@ -20,6 +21,7 @@ describe 'Resident API' do
       expect(response).to have_http_status :ok
       expect(response.content_type).to include 'application/json'
       expect(response.parsed_body['resident_type']).to eq 'tenant'
+      expect(response.parsed_body['unit_id']).to eq resident.unit_id
     end
 
     it "successfully and there's no match on the database" do
@@ -29,6 +31,7 @@ describe 'Resident API' do
       expect(response).to have_http_status :ok
       expect(response.content_type).to include 'application/json'
       expect(response.parsed_body['resident_type']).to eq 'inexistent'
+      expect(response.parsed_body['unit_id']).to eq 'nil'
     end
 
     it 'and fail if the registration number is invalid' do

--- a/spec/requests/apis/resident_spec.rb
+++ b/spec/requests/apis/resident_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe 'Resident API' do
-  context 'GET /api/v1/check_registration_number?' do
+  context 'GET /api/v1/check_registration_number?registration_number=' do
     it 'successfully and is an owner' do
       resident = create(:resident, registration_number: '076.550.640-83', resident_type: :owner)
 
@@ -31,7 +31,22 @@ describe 'Resident API' do
       expect(response.parsed_body['resident_type']).to eq 'inexistent'
     end
 
-    it "and fail if there's an internal server error" do
+    it 'and fail if the registration number is invalid' do
+      registration_number = '111.111.111-11'
+      get "/api/v1/check_registration_number?registration_number=#{registration_number}"
+
+      expect(response).to have_http_status :precondition_failed
+      expect(response.content_type).to include 'application/json'
+      expect(response.parsed_body['error']).to eq 'invalid registration number'
+    end
+
+    it 'and returns 500 if internal error' do
+      resident = create(:resident, registration_number: '076.550.640-83', resident_type: :owner)
+      allow(Resident).to receive(:find_by).and_raise ActiveRecord::ActiveRecordError
+
+      get "/api/v1/check_registration_number?registration_number=#{resident.registration_number}"
+
+      expect(response).to have_http_status :internal_server_error
     end
   end
 end


### PR DESCRIPTION
### Título
Como sistema externo, é possível validar se o CPF informado é de um proprietário/morador de um imóvel, para que se saiba se um determinado CPF é de um proprietário/morador existente na aplicação.

### Objetivo
Permitir que a aplicação [PagueAluguel](https://github.com/TreinaDev/pague-aluguel) consiga validar, a partir do CPF, se determinado usuário é morador ou proprietário de uma unidade no [CondoMinions](https://github.com/TreinaDev/condominions)

### Endpoint
`GET /api/v1/check_registration_number?registration_number={CPF}`

Retorna o perfil do usuário do CondoMinions e, caso exista, o id de sua unidade.

Exemplos de resposta:

```
{
  "profile": "owner",
  "unit_id": "1"
}
```

```
{
  "profile": "tenant",
  "unit_id": "10"
}
```

```
{
  "profile": "inexistent",
  "unit_id": "nil"
}
```

OBS: Caso o CPF seja inválido, será retornado o erro 412 (precondition failed) e o json com o campo 'error'.

```
{
  "error": "invalid registration number"
}
``

Adicionalmente, atualiza o readme com a documentação necessária para consumir o novo endpoint da API.

Resolve a issue #53 