### PR TITLE
Refatoração da criação de andares e unidades

### DIFF
--- a/app/controllers/towers_controller.rb
+++ b/app/controllers/towers_controller.rb
@@ -27,7 +27,6 @@ class TowersController < ApplicationController
     @tower = Tower.new tower_params.merge! condo: @condo
 
     if @tower.save
-      @tower.generate_floors
       return redirect_to edit_floor_units_condo_tower_path(@tower.condo, @tower),
                          notice: t('notices.tower.created')
     end

--- a/app/models/tower.rb
+++ b/app/models/tower.rb
@@ -10,13 +10,15 @@ class Tower < ApplicationRecord
     greater_than: 0, only_integer: true
   }
 
-  def generate_floors
-    floor_quantity.times { create_floor_with_units }
-  end
+  after_create :generate_floors
 
   def warning_html_message
     "Cadastro do(a) <strong>#{name}</strong> do(a) <strong>#{condo.name}</strong> " \
       "incompleto(a), por favor, atualize o pavimento tipo.\n"
+  end
+
+  def generate_floors
+    floor_quantity.times { create_floor_with_units }
   end
 
   private

--- a/spec/mailers/resident_mailer_spec.rb
+++ b/spec/mailers/resident_mailer_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe ResidentMailer, type: :mailer do
     it 'send to resident email' do
       condo = create :condo, name: 'Condominio Certo'
       tower = create :tower, 'condo' => condo, name: 'Torre correta', floor_quantity: 2, units_per_floor: 4
-      tower.generate_floors
       first_floor = tower.floors[0]
       third_unit = first_floor.units[2]
       resident_joao = create :resident, full_name: 'João Carvalho', resident_type: :owner,

--- a/spec/models/floor_spec.rb
+++ b/spec/models/floor_spec.rb
@@ -3,10 +3,8 @@ require 'rails_helper'
 RSpec.describe Floor, type: :model do
   describe '#generate_units' do
     it 'Generate units for this floor' do
-      tower = build :tower, units_per_floor: 4
-      floor = build(:floor, tower:)
-
-      floor.generate_units
+      tower = create :tower, units_per_floor: 4
+      floor = tower.floors[0]
 
       expect(floor.units.count).to eq 4
     end
@@ -14,8 +12,7 @@ RSpec.describe Floor, type: :model do
 
   describe '#identifier' do
     it 'returns identifier' do
-      tower = build :tower, units_per_floor: 4
-      tower.generate_floors
+      tower = create :tower, units_per_floor: 4
 
       expect(tower.floors[2].identifier).to eq 3
     end
@@ -23,8 +20,7 @@ RSpec.describe Floor, type: :model do
 
   describe '#print_identifier' do
     it 'returns identifier description' do
-      tower = build :tower, units_per_floor: 4
-      tower.generate_floors
+      tower = create :tower, units_per_floor: 4
 
       expect(tower.floors[2].print_identifier).to eq '3º Andar'
     end
@@ -35,9 +31,7 @@ RSpec.describe Floor, type: :model do
       first_unit_type =  create :unit_type, description: 'Apartamento de 1 quarto', metreage: 50.55
       second_unit_type = create :unit_type, description: 'Apartamento de 2 quartos', metreage: 80.75
       tower = create :tower, units_per_floor: 5, floor_quantity: 3
-      tower.generate_floors
       floor = tower.floors[1]
-      floor.generate_units
 
       floor.units[0].update unit_type: second_unit_type
       floor.units[1].update unit_type: first_unit_type

--- a/spec/models/tower_spec.rb
+++ b/spec/models/tower_spec.rb
@@ -3,9 +3,7 @@ require 'rails_helper'
 RSpec.describe Tower, type: :model do
   describe '#generate_floors' do
     it 'Generate floors for this tower' do
-      tower = build :tower, floor_quantity: 3
-
-      tower.generate_floors
+      tower = create :tower, floor_quantity: 3
 
       expect(tower.floors.count).to eq 3
     end

--- a/spec/models/unit_spec.rb
+++ b/spec/models/unit_spec.rb
@@ -4,9 +4,7 @@ RSpec.describe Unit, type: :model do
   describe '#print_identifier' do
     it 'returns identifier description' do
       tower = create :tower, units_per_floor: 5, floor_quantity: 3
-      tower.generate_floors
       floor = tower.floors[1]
-      floor.generate_units
       unit = floor.units.first
 
       expect(unit.print_identifier).to eq 'Unidade 21'

--- a/spec/requests/apis/unit_type_spec.rb
+++ b/spec/requests/apis/unit_type_spec.rb
@@ -36,10 +36,6 @@ describe 'Unit Type API' do
                            units_per_floor: 3,
                            condo: first_condo
 
-      first_tower.generate_floors
-      second_tower.generate_floors
-      third_tower.generate_floors
-
       first_tower.floors.each do |floor|
         floor.units[0].update unit_type: first_unit_type
         floor.units[1].update unit_type: third_unit_type

--- a/spec/requests/tower_spec.rb
+++ b/spec/requests/tower_spec.rb
@@ -19,7 +19,6 @@ describe 'PATCH /towers' do
   it 'must be authenticated to register a tower' do
     condo = create :condo
     tower = create(:tower, floor_quantity: 3, units_per_floor: 2, condo:)
-    tower.generate_floors
 
     patch update_floor_units_condo_tower_path(condo, tower)
 

--- a/spec/system/floors/administrator_sees_floor_details_spec.rb
+++ b/spec/system/floors/administrator_sees_floor_details_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 describe "Administrator sees floor's details" do
   it 'only if authenticated' do
     tower = create :tower, units_per_floor: 5, floor_quantity: 3
-    tower.generate_floors
     floor = tower.floors[1]
 
     visit tower_floor_path(tower, floor)
@@ -21,8 +20,7 @@ describe "Administrator sees floor's details" do
                               description: 'Apartamento de 2 quartos',
                               metreage: 80.75
 
-    tower = create(:tower, name: 'Torre A', units_per_floor: 5, floor_quantity: 3)
-    tower.generate_floors
+    tower = create :tower, name: 'Torre A', units_per_floor: 5, floor_quantity: 3
     floor = tower.floors[1]
 
     floor.units[0].update unit_type: second_unit_type
@@ -55,8 +53,7 @@ describe "Administrator sees floor's details" do
 
   it "and returns to floor type registration if it isn't registered yet" do
     user = create :manager
-    tower = build :tower
-    tower.generate_floors
+    tower = create :tower
     floor = tower.floors.first
 
     login_as user, scope: :manager

--- a/spec/system/resident/manager_register_new_resident_spec.rb
+++ b/spec/system/resident/manager_register_new_resident_spec.rb
@@ -6,8 +6,7 @@ describe 'Manager registers new resident' do
     create :condo, name: 'Condominio Errado'
     condo = create :condo, name: 'Condominio Certo'
     create :tower, 'condo' => condo, name: 'Torre errada'
-    tower = create :tower, 'condo' => condo, name: 'Torre correta', floor_quantity: 2, units_per_floor: 2
-    tower.generate_floors
+    create :tower, 'condo' => condo, name: 'Torre correta', floor_quantity: 2, units_per_floor: 2
 
     mail = double 'mail', deliver: true
     mailer_double = double 'ResidentMailer', notify_new_resident: mail

--- a/spec/system/resident/resident_confirms_data_spec.rb
+++ b/spec/system/resident/resident_confirms_data_spec.rb
@@ -13,7 +13,6 @@ describe 'Resident confirms data' do
   it 'and see registered data' do
     condo = create :condo, name: 'Condominio Certo'
     tower = create :tower, 'condo' => condo, name: 'Torre correta', floor_quantity: 2, units_per_floor: 4
-    tower.generate_floors
     first_floor = tower.floors[0]
     third_unit = first_floor.units[2]
 

--- a/spec/system/towers/administrator_register_floor_type_spec.rb
+++ b/spec/system/towers/administrator_register_floor_type_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 describe 'Administrator edit floor type' do
   it 'only if authenticated' do
     tower = create :tower
-    tower.generate_floors
     create :unit_type, description: 'Apartamento de 1 quarto'
     create :unit_type, description: 'Apartamento de 2 quartos'
 
@@ -16,7 +15,6 @@ describe 'Administrator edit floor type' do
     user = create :manager
     condo = create :condo, name: 'Condomínio A'
     tower = create :tower, condo:, name: 'Torre A'
-    tower.generate_floors
 
     create :unit_type, description: 'Apartamento de 1 quarto'
     create :unit_type, description: 'Apartamento de 2 quartos'
@@ -55,7 +53,6 @@ describe 'Administrator edit floor type' do
   it 'and fails if there is unselected unit types' do
     user = create :manager
     tower = create :tower
-    tower.generate_floors
 
     create :unit_type, description: 'Apartamento de 1 quarto'
     create :unit_type, description: 'Apartamento de 2 quartos'
@@ -85,7 +82,6 @@ describe 'Administrator edit floor type' do
       user = create :manager
       condo = create :condo, name: 'Condomínio A'
       tower = create :tower, condo:, name: 'Torre B'
-      tower.generate_floors
 
       login_as user, scope: :manager
       visit root_path
@@ -102,7 +98,6 @@ describe 'Administrator edit floor type' do
       user = create :manager
       condo = create :condo, name: 'Condomínio A'
       tower = create :tower, condo:, name: 'Torre B'
-      tower.generate_floors
 
       login_as user, scope: :manager
       visit tower_path tower
@@ -113,8 +108,7 @@ describe 'Administrator edit floor type' do
 
     it 'only if authenticated' do
       condo = create :condo, name: 'Condomínio A'
-      tower = create :tower, condo:, name: 'Torre B'
-      tower.generate_floors
+      create :tower, condo:, name: 'Torre B'
 
       visit root_path
 

--- a/spec/system/towers/administrator_sees_condo_tower_details_spec.rb
+++ b/spec/system/towers/administrator_sees_condo_tower_details_spec.rb
@@ -2,8 +2,7 @@ require 'rails_helper'
 
 describe "Administrator sees tower's details" do
   it 'only if authenticated' do
-    tower = build(:tower)
-    tower.generate_floors
+    tower = create :tower
 
     visit tower_path tower
 
@@ -12,8 +11,7 @@ describe "Administrator sees tower's details" do
 
   it "and sees a list of tower's floors" do
     user = create :manager
-    tower = build :tower, name: 'Torre A', floor_quantity: 3
-    tower.generate_floors
+    tower = create :tower, name: 'Torre A', floor_quantity: 3
 
     login_as user, scope: :manager
     visit tower_path tower

--- a/spec/system/towers/administrator_view_condo_towers_spec.rb
+++ b/spec/system/towers/administrator_view_condo_towers_spec.rb
@@ -13,14 +13,10 @@ describe 'Administrator view list of towers' do
     condo = create(:condo)
     condo2 = create(:condo)
     user = create :manager
-    tower_a = build :tower, name: 'Torre A', condo_id: condo.id
-    tower_a.generate_floors
-    tower_b = build :tower, name: 'Torre B', condo_id: condo.id
-    tower_b.generate_floors
-    tower_c = build :tower, name: 'Torre C', condo_id: condo.id
-    tower_c.generate_floors
-    tower_z = build :tower, name: 'Torre Z', condo_id: condo2.id
-    tower_z.generate_floors
+    create :tower, name: 'Torre A', condo_id: condo.id
+    create :tower, name: 'Torre B', condo_id: condo.id
+    create :tower, name: 'Torre C', condo_id: condo.id
+    create :tower, name: 'Torre Z', condo_id: condo2.id
 
     login_as user, scope: :manager
     visit condo_path(condo)
@@ -38,8 +34,7 @@ describe 'Administrator view list of towers' do
   it 'and see a tower details when click on tower´s name' do
     condo = create(:condo)
     user = create :manager
-    tower_a = build :tower, name: 'Torre A', condo_id: condo.id
-    tower_a.generate_floors
+    tower_a = create :tower, name: 'Torre A', condo_id: condo.id
 
     login_as user, scope: :manager
     visit condo_path(condo)

--- a/spec/system/units/administrator_sees_unit_details_spec.rb
+++ b/spec/system/units/administrator_sees_unit_details_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 describe "Administrator sees unit's details" do
   it 'only if authenticated' do
     tower = create :tower
-    tower.generate_floors
     floor = tower.floors.first
 
     visit tower_floor_unit_path(tower, floor, floor.units[1])
@@ -18,7 +17,6 @@ describe "Administrator sees unit's details" do
                       metreage: 50.55
 
     tower = create :tower
-    tower.generate_floors
     floor = tower.floors.first
     floor.units[1].update(unit_type:)
 

--- a/spec/system/user_sees_breadcrumb_spec.rb
+++ b/spec/system/user_sees_breadcrumb_spec.rb
@@ -13,7 +13,6 @@ describe 'User sees breadcrumb' do
 
     condo = create :condo, name: 'Condominio Residencial Paineiras'
     tower = create(:tower, name: 'Torre A', units_per_floor: 5, floor_quantity: 3, condo:)
-    tower.generate_floors
     floor = tower.floors[1]
 
     floor.units[0].update unit_type: second_unit_type


### PR DESCRIPTION
Este PR refatora a lógica de criação de andares e unidades de uma torre no momento de criação de uma torre, removendo a chamada de método manual no controller, para melhor otimização do sistema e evitar duplicação de código. Também foram refatorados os testes em que os métodos foram chamados.

Resolve #65 