### PR TITLE
Calcula fracao ideal

### DIFF
--- a/app/controllers/towers_controller.rb
+++ b/app/controllers/towers_controller.rb
@@ -53,7 +53,6 @@ class TowersController < ApplicationController
       end
     end
 
-    UnitType.update_fractions(@tower.condo)
     @tower.complete!
   end
 

--- a/app/controllers/towers_controller.rb
+++ b/app/controllers/towers_controller.rb
@@ -54,6 +54,7 @@ class TowersController < ApplicationController
       end
     end
 
+    UnitType.update_fractions(@tower.condo)
     @tower.complete!
   end
 

--- a/app/controllers/towers_controller.rb
+++ b/app/controllers/towers_controller.rb
@@ -1,7 +1,7 @@
 class TowersController < ApplicationController
   before_action :authenticate_manager!, only: %i[index show new edit_floor_units create update_floor_units]
   before_action :set_tower, only: %i[show edit_floor_units update_floor_units]
-  before_action :set_condo, only: %i[index new create]
+  before_action :set_condo, only: %i[index edit_floor_units new create]
 
   before_action :set_breadcrumbs_for_details, only: %i[show edit_floor_units update_floor_units]
   before_action :set_breadcrumbs_for_register, only: %i[new create]
@@ -20,7 +20,7 @@ class TowersController < ApplicationController
 
   def edit_floor_units
     add_breadcrumb I18n.t('breadcrumb.tower.floor_type')
-    @unit_types = UnitType.order :description
+    @unit_types = @condo.unit_types.order :description
   end
 
   def create

--- a/app/models/condo.rb
+++ b/app/models/condo.rb
@@ -20,6 +20,15 @@ class Condo < ApplicationRecord
     HEREDOC
   end
 
+  def calculate_total_area
+    total_area = 0
+    unit_types.each do |unit_type|
+      total_area += unit_type.metreage * unit_type.units.count
+    end
+
+    total_area
+  end
+
   private
 
   def validate_cnpj

--- a/app/models/condo.rb
+++ b/app/models/condo.rb
@@ -20,6 +20,16 @@ class Condo < ApplicationRecord
     HEREDOC
   end
 
+  def set_unit_types_fractions
+    total_area = calculate_total_area
+    unit_types.each do |unit_type|
+      fraction = (unit_type.metreage / total_area * 100).round(5)
+      unit_type.update!(fraction:)
+    end
+  end
+
+  private
+
   def calculate_total_area
     total_area = 0
     unit_types.each do |unit_type|
@@ -28,8 +38,6 @@ class Condo < ApplicationRecord
 
     total_area
   end
-
-  private
 
   def validate_cnpj
     if CNPJ.valid? registration_number

--- a/app/models/condo.rb
+++ b/app/models/condo.rb
@@ -22,6 +22,8 @@ class Condo < ApplicationRecord
 
   def set_unit_types_fractions
     total_area = calculate_total_area
+    return if total_area.zero?
+
     unit_types.each do |unit_type|
       fraction = (unit_type.metreage / total_area * 100).round(5)
       unit_type.update!(fraction:)

--- a/app/models/tower.rb
+++ b/app/models/tower.rb
@@ -17,11 +17,17 @@ class Tower < ApplicationRecord
       "incompleto(a), por favor, atualize o pavimento tipo.\n"
   end
 
-  def generate_floors
-    floor_quantity.times { create_floor_with_units }
+  def complete!
+    condo.set_unit_types_fractions
+
+    super
   end
 
   private
+
+  def generate_floors
+    floor_quantity.times { create_floor_with_units }
+  end
 
   def create_floor_with_units
     floor = Floor.create tower: self

--- a/app/models/unit_type.rb
+++ b/app/models/unit_type.rb
@@ -5,6 +5,8 @@ class UnitType < ApplicationRecord
   validates :description, :metreage, presence: true
   validates :metreage, numericality: { greater_than: 0 }
 
+  after_update :update_fraction, if: :metreage_previously_changed?
+
   def metreage_to_square_meters
     "#{metreage}m²"
   end
@@ -17,5 +19,11 @@ class UnitType < ApplicationRecord
 
   def unit_ids
     units.pluck :id
+  end
+
+  private
+
+  def update_fraction
+    condo.set_unit_types_fractions
   end
 end

--- a/app/models/unit_type.rb
+++ b/app/models/unit_type.rb
@@ -18,12 +18,4 @@ class UnitType < ApplicationRecord
   def unit_ids
     units.pluck :id
   end
-
-  def self.update_fractions(condo)
-    total_area = condo.calculate_total_area
-    condo.unit_types.each do |unit_type|
-      fraction = (unit_type.metreage / total_area * 100).round(5)
-      unit_type.update!(fraction:)
-    end
-  end
 end

--- a/app/models/unit_type.rb
+++ b/app/models/unit_type.rb
@@ -2,18 +2,28 @@ class UnitType < ApplicationRecord
   has_many :units, dependent: :destroy
   belongs_to :condo
 
-  validates :description, :metreage, :fraction, presence: true
-  validates :metreage, :fraction, numericality: { greater_than: 0 }
+  validates :description, :metreage, presence: true
+  validates :metreage, numericality: { greater_than: 0 }
 
   def metreage_to_square_meters
     "#{metreage}m²"
   end
 
   def fraction_to_percentage
+    return 'Não definida' if fraction.nil?
+
     "#{fraction}%"
   end
 
   def unit_ids
     units.pluck :id
+  end
+
+  def self.update_fractions(condo)
+    total_area = condo.calculate_total_area
+    condo.unit_types.each do |unit_type|
+      fraction = (unit_type.metreage / total_area * 100).round(5)
+      unit_type.update!(fraction:)
+    end
   end
 end

--- a/app/views/unit_types/_form.html.erb
+++ b/app/views/unit_types/_form.html.erb
@@ -9,11 +9,6 @@
       <%= f.label :metreage %>
       <%= f.number_field :metreage, step: 0.01, class:"form-control"%>
     </div>
-
-    <div class="form-group col-md-4 pe-3">
-      <%= f.label :fraction %> (Valor em porcentagem)
-      <%= f.number_field :fraction, step: 0.00001, class:"form-control"%>
-    </div>
   </div>
 
   <div>

--- a/spec/factories/towers.rb
+++ b/spec/factories/towers.rb
@@ -4,5 +4,23 @@ FactoryBot.define do
     units_per_floor { 4 }
     name { 'Torre A' }
     condo { build :condo }
+
+    trait :with_four_units do
+      transient do
+        unit_types { [] }
+      end
+
+      after(:create) do |tower, evaluator|
+        unit_types = evaluator.unit_types
+
+        tower.floors.each do |floor|
+          floor.units[0].update(unit_type: unit_types[0])
+          floor.units[1].update(unit_type: unit_types[1])
+          floor.units[2].update(unit_type: unit_types[0])
+          floor.units[3].update(unit_type: unit_types[1])
+        end
+        tower.complete!
+      end
+    end
   end
 end

--- a/spec/factories/towers.rb
+++ b/spec/factories/towers.rb
@@ -14,10 +14,10 @@ FactoryBot.define do
         unit_types = evaluator.unit_types
 
         tower.floors.each do |floor|
-          floor.units[0].update(unit_type: unit_types[0])
-          floor.units[1].update(unit_type: unit_types[1])
-          floor.units[2].update(unit_type: unit_types[0])
-          floor.units[3].update(unit_type: unit_types[1])
+          floor.units[0].update(unit_type: unit_types[0 % unit_types.size])
+          floor.units[1].update(unit_type: unit_types[1 % unit_types.size])
+          floor.units[2].update(unit_type: unit_types[2 % unit_types.size])
+          floor.units[3].update(unit_type: unit_types[3 % unit_types.size])
         end
         tower.complete!
       end

--- a/spec/factories/unit_types.rb
+++ b/spec/factories/unit_types.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :unit_type do
     description { 'Apartamento de 1 quarto' }
     metreage { 50.55 }
-    fraction { 3 }
+    fraction { nil }
     condo { build :condo }
   end
 end

--- a/spec/models/condo_spec.rb
+++ b/spec/models/condo_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Condo, type: :model do
   describe '#set_units_type_fractions' do
     context 'after define units types in condo tower floors' do
-      it 'calculate sucessfully' do
+      it 'calculate successfully' do
         condo = create(:condo)
         first_unit_type = create :unit_type,
                                  description: 'Apartamento de 1 quarto',

--- a/spec/models/condo_spec.rb
+++ b/spec/models/condo_spec.rb
@@ -1,6 +1,37 @@
 require 'rails_helper'
 
 RSpec.describe Condo, type: :model do
+  describe '#set_units_type_fractions' do
+    context 'after define units types in condo tower floors' do
+      it 'calculate sucessfully' do
+        condo = create(:condo)
+        first_unit_type = create :unit_type,
+                                 description: 'Apartamento de 1 quarto',
+                                 condo:,
+                                 metreage: 50,
+                                 fraction: nil
+        second_unit_type = create :unit_type,
+                                  description: 'Apartamento de 2 quartos',
+                                  condo:,
+                                  metreage: 150,
+                                  fraction: nil
+        tower = create :tower,
+                       floor_quantity: 5,
+                       condo:,
+                       units_per_floor: 2
+
+        tower.floors.each do |floor|
+          floor.units[0].update unit_type: first_unit_type
+          floor.units[1].update unit_type: second_unit_type
+        end
+        condo.set_unit_types_fractions
+
+        expect(first_unit_type.reload.fraction).to eq(5)
+        expect(second_unit_type.reload.fraction).to eq(15)
+      end
+    end
+  end
+
   describe '#valid' do
     context 'presence' do
       it 'false when params are empty' do

--- a/spec/models/unit_type_spec.rb
+++ b/spec/models/unit_type_spec.rb
@@ -1,55 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe UnitType, type: :model do
-  context '#update_fractions' do
-    it 'All added together should give 100' do
-      condo = create(:condo)
-      unit_type1 = create(:unit_type, description: 'Apartamento de 1 quarto', condo:, metreage: 50)
-      unit_type2 = create(:unit_type, description: 'Apartamento de 2 quartos', condo:, metreage: 100)
-
-      tower1 = create(:tower, floor_quantity: 5, condo:, units_per_floor: 2)
-      tower1.generate_floors
-      tower1.floors.each do |floor|
-        floor.units[0].update unit_type: unit_type1
-        floor.units[1].update unit_type: unit_type2
-      end
-      UnitType.update_fractions(tower1.condo)
-      unit_type1.reload
-      unit_type2.reload
-
-      sum = (unit_type1.fraction * unit_type1.units.count) + (unit_type2.fraction * unit_type2.units.count)
-      expect(sum).to eq 100
-    end
-
-    it 'update fractions for all unit types' do
-      condo = create(:condo)
-      unit_type1 = create(:unit_type, description: 'Apartamento de 1 quarto', condo:, metreage: 50)
-      unit_type2 = create(:unit_type, description: 'Apartamento de 2 quartos', condo:, metreage: 100)
-
-      tower1 = create(:tower, floor_quantity: 5, condo:, units_per_floor: 2)
-      tower1.generate_floors
-      tower1.floors.each do |floor|
-        floor.units[0].update unit_type: unit_type1
-        floor.units[1].update unit_type: unit_type1
-      end
-      UnitType.update_fractions(tower1.condo)
-      unit_type1.reload
-      fraction1 = unit_type1.fraction
-
-      tower2 = create(:tower, floor_quantity: 5, condo:, units_per_floor: 2)
-      tower2.generate_floors
-      tower2.floors.each do |floor|
-        floor.units[0].update unit_type: unit_type2
-        floor.units[1].update unit_type: unit_type2
-      end
-      UnitType.update_fractions(tower1.condo)
-      unit_type1.reload
-      fraction2 = unit_type1.fraction
-
-      expect(fraction1).not_to eq fraction2
-    end
-  end
-
   context '#unit_ids' do
     it "return ids from unit type's units" do
       unit_type = build :unit_type

--- a/spec/models/unit_type_spec.rb
+++ b/spec/models/unit_type_spec.rb
@@ -1,6 +1,55 @@
 require 'rails_helper'
 
 RSpec.describe UnitType, type: :model do
+  context '#update_fractions' do
+    it 'All added together should give 100' do
+      condo = create(:condo)
+      unit_type1 = create(:unit_type, description: 'Apartamento de 1 quarto', condo:, metreage: 50)
+      unit_type2 = create(:unit_type, description: 'Apartamento de 2 quartos', condo:, metreage: 100)
+
+      tower1 = create(:tower, floor_quantity: 5, condo:, units_per_floor: 2)
+      tower1.generate_floors
+      tower1.floors.each do |floor|
+        floor.units[0].update unit_type: unit_type1
+        floor.units[1].update unit_type: unit_type2
+      end
+      UnitType.update_fractions(tower1.condo)
+      unit_type1.reload
+      unit_type2.reload
+
+      sum = (unit_type1.fraction * unit_type1.units.count) + (unit_type2.fraction * unit_type2.units.count)
+      expect(sum).to eq 100
+    end
+
+    it 'update fractions for all unit types' do
+      condo = create(:condo)
+      unit_type1 = create(:unit_type, description: 'Apartamento de 1 quarto', condo:, metreage: 50)
+      unit_type2 = create(:unit_type, description: 'Apartamento de 2 quartos', condo:, metreage: 100)
+
+      tower1 = create(:tower, floor_quantity: 5, condo:, units_per_floor: 2)
+      tower1.generate_floors
+      tower1.floors.each do |floor|
+        floor.units[0].update unit_type: unit_type1
+        floor.units[1].update unit_type: unit_type1
+      end
+      UnitType.update_fractions(tower1.condo)
+      unit_type1.reload
+      fraction1 = unit_type1.fraction
+
+      tower2 = create(:tower, floor_quantity: 5, condo:, units_per_floor: 2)
+      tower2.generate_floors
+      tower2.floors.each do |floor|
+        floor.units[0].update unit_type: unit_type2
+        floor.units[1].update unit_type: unit_type2
+      end
+      UnitType.update_fractions(tower1.condo)
+      unit_type1.reload
+      fraction2 = unit_type1.fraction
+
+      expect(fraction1).not_to eq fraction2
+    end
+  end
+
   context '#unit_ids' do
     it "return ids from unit type's units" do
       unit_type = build :unit_type
@@ -12,12 +61,11 @@ RSpec.describe UnitType, type: :model do
 
   context '#valid?' do
     it 'missing params' do
-      unit_type = UnitType.new(description: '', metreage: '', fraction: '')
+      unit_type = UnitType.new(description: '', metreage: '')
 
       expect(unit_type).not_to be_valid
       expect(unit_type.errors).to include(:description)
       expect(unit_type.errors).to include(:metreage)
-      expect(unit_type.errors).to include(:fraction)
     end
 
     context 'Metreage must be bigger than zero' do
@@ -32,21 +80,6 @@ RSpec.describe UnitType, type: :model do
 
         expect(unit_type).not_to be_valid
         expect(unit_type.errors.full_messages).to include('Metragem deve ser maior que 0')
-      end
-    end
-
-    context 'Fraction must be bigger than zero' do
-      it 'fraction equal zero' do
-        unit_type = UnitType.new(fraction: 0)
-
-        expect(unit_type).not_to be_valid
-        expect(unit_type.errors.full_messages).to include('Fração Ideal deve ser maior que 0')
-      end
-      it 'fraction less than zero' do
-        unit_type = UnitType.new(fraction: -1)
-
-        expect(unit_type).not_to be_valid
-        expect(unit_type.errors.full_messages).to include('Fração Ideal deve ser maior que 0')
       end
     end
   end

--- a/spec/requests/tower_spec.rb
+++ b/spec/requests/tower_spec.rb
@@ -13,10 +13,24 @@ describe 'POST /towers' do
     expect(response).to redirect_to new_manager_session_path
     expect(flash[:alert]).to eq 'Para continuar, faça login ou registre-se.'
   end
+
+  it 'and can only be authenticated as a manager to register a tower' do
+    resident = create :resident
+    condo = create :condo
+
+    login_as resident, scope: :resident
+    post condo_towers_path(condo),
+         params: { tower:
+                         { name: 'Torre do Rubinhos',
+                           floor_quantity: 3,
+                           units_per_floor: 4 } }
+
+    expect(response).to redirect_to root_path
+  end
 end
 
-describe 'PATCH /towers' do
-  it 'must be authenticated to register a tower' do
+describe 'PATCH /update_floor_units' do
+  it 'must be authenticated to update floor units from a tower' do
     condo = create :condo
     tower = create(:tower, floor_quantity: 3, units_per_floor: 2, condo:)
 
@@ -24,6 +38,17 @@ describe 'PATCH /towers' do
 
     expect(response).to redirect_to new_manager_session_path
     expect(flash[:alert]).to eq 'Para continuar, faça login ou registre-se.'
+  end
+
+  it 'and can only be authenticated as a manager to update floor units from a tower' do
+    condo = create :condo
+    tower = create(:tower, floor_quantity: 3, units_per_floor: 2, condo:)
+    resident = create :resident
+
+    login_as resident, scope: :resident
+    patch update_floor_units_condo_tower_path(condo, tower)
+
+    expect(response).to redirect_to root_path
   end
 
   it 'and updates all unit type fractions within the condo' do

--- a/spec/requests/tower_spec.rb
+++ b/spec/requests/tower_spec.rb
@@ -26,6 +26,7 @@ describe 'POST /towers' do
                            units_per_floor: 4 } }
 
     expect(response).to redirect_to root_path
+    expect(Tower.last.name).not_to eq 'Torre do Rubinhos'
   end
 end
 

--- a/spec/requests/tower_spec.rb
+++ b/spec/requests/tower_spec.rb
@@ -25,4 +25,22 @@ describe 'PATCH /towers' do
     expect(response).to redirect_to new_manager_session_path
     expect(flash[:alert]).to eq 'Para continuar, faça login ou registre-se.'
   end
+
+  it 'and updates all unit type fractions within the condo' do
+    manager = create :manager
+    condo = create :condo
+    first_unit_type = create(:unit_type, condo:, metreage: 50)
+    second_unit_type = create(:unit_type, condo:, metreage: 100)
+    create(:tower, :with_four_units, floor_quantity: 3, condo:, unit_types: [first_unit_type, second_unit_type])
+
+    tower = create(:tower, floor_quantity: 3, units_per_floor: 2, condo:)
+    unit_types = { '0' => first_unit_type.id, '1' => second_unit_type.id }
+
+    login_as manager, scope: :manager
+    patch update_floor_units_condo_tower_path(condo, tower), params: { unit_types: }
+    tower.reload
+
+    expect(first_unit_type.reload.fraction).to eq 3.7037
+    expect(second_unit_type.reload.fraction).to eq 7.40741
+  end
 end

--- a/spec/system/towers/administrator_register_floor_type_spec.rb
+++ b/spec/system/towers/administrator_register_floor_type_spec.rb
@@ -77,64 +77,18 @@ describe 'Administrator edit floor type' do
     expect(page).to have_content 'Defina o tipo de unidade para todas as unidades'
   end
 
-  context 'and update unit_types fraction' do
-    it 'successfully' do
-      user = create :manager
-      condo = create :condo
-      tower = create :tower, floor_quantity: 5, condo:, units_per_floor: 2
+  it 'and update unit_types fraction' do
+    user = create :manager
+    condo = create :condo
+    first_unit_type = create :unit_type, description: 'Apartamento de 1 quarto', condo:, metreage: 50, fraction: nil
+    second_unit_type = create :unit_type, description: 'Apartamento de 2 quartos', condo:, metreage: 150
+    create(:tower, :with_four_units, floor_quantity: 5, condo:, unit_types: [first_unit_type, second_unit_type])
 
-      unit_type = create :unit_type, description: 'Apartamento de 1 quarto', condo:, metreage: 50
-      create :unit_type, description: 'Apartamento de 2 quartos', condo:, metreage: 100
+    login_as user, scope: :manager
+    visit condo_unit_type_path(condo, first_unit_type)
 
-      login_as user, scope: :manager
-      visit edit_floor_units_condo_tower_path(condo, tower)
-
-      within '#unit-1' do
-        select 'Apartamento de 1 quarto', from: 'Unidade modelo 1'
-      end
-
-      within '#unit-2' do
-        select 'Apartamento de 2 quartos', from: 'Unidade modelo 2'
-      end
-
-      click_on 'Atualizar Pavimento Tipo'
-
-      visit condo_unit_type_path(condo, unit_type)
-
-      expect(page).to have_content 'Fração Ideal: 6.66667%'
-    end
-
-    it 'after any tower create' do
-      user = create :manager
-      condo = create :condo
-      unit_type1 = create :unit_type, description: 'Apartamento de 1 quarto', condo:, metreage: 50
-      unit_type2 = create :unit_type, description: 'Apartamento de 2 quartos', condo:, metreage: 100
-      tower1 = create :tower, floor_quantity: 5, condo:, units_per_floor: 2
-
-      tower1.floors.each do |floor|
-        floor.units[0].update unit_type: unit_type1
-        floor.units[1].update unit_type: unit_type2
-      end
-      UnitType.update_fractions(tower1.condo)
-
-      tower2 = create :tower, floor_quantity: 5, condo:, units_per_floor: 2
-
-      login_as user, scope: :manager
-      visit edit_floor_units_condo_tower_path(condo, tower2)
-
-      within '#unit-1' do
-        select 'Apartamento de 1 quarto', from: 'Unidade modelo 1'
-      end
-
-      within '#unit-2' do
-        select 'Apartamento de 2 quartos', from: 'Unidade modelo 2'
-      end
-
-      click_on 'Atualizar Pavimento Tipo'
-
-      visit condo_unit_type_path(condo, unit_type1)
-      expect(page).to have_content 'Fração Ideal: 3.33333%'
-    end
+    expect(page).to have_content 'Fração Ideal: 2.5%'
+    expect(page).not_to have_content 'Não definido'
   end
 
   context 'see a warning if registration is not complete' do

--- a/spec/system/towers/administrator_register_floor_type_spec.rb
+++ b/spec/system/towers/administrator_register_floor_type_spec.rb
@@ -82,7 +82,6 @@ describe 'Administrator edit floor type' do
       user = create :manager
       condo = create :condo
       tower = create :tower, floor_quantity: 5, condo:, units_per_floor: 2
-      tower.generate_floors
 
       unit_type = create :unit_type, description: 'Apartamento de 1 quarto', condo:, metreage: 50
       create :unit_type, description: 'Apartamento de 2 quartos', condo:, metreage: 100
@@ -111,7 +110,6 @@ describe 'Administrator edit floor type' do
       unit_type1 = create :unit_type, description: 'Apartamento de 1 quarto', condo:, metreage: 50
       unit_type2 = create :unit_type, description: 'Apartamento de 2 quartos', condo:, metreage: 100
       tower1 = create :tower, floor_quantity: 5, condo:, units_per_floor: 2
-      tower1.generate_floors
 
       tower1.floors.each do |floor|
         floor.units[0].update unit_type: unit_type1
@@ -120,7 +118,6 @@ describe 'Administrator edit floor type' do
       UnitType.update_fractions(tower1.condo)
 
       tower2 = create :tower, floor_quantity: 5, condo:, units_per_floor: 2
-      tower2.generate_floors
 
       login_as user, scope: :manager
       visit edit_floor_units_condo_tower_path(condo, tower2)

--- a/spec/system/towers/administrator_register_floor_type_spec.rb
+++ b/spec/system/towers/administrator_register_floor_type_spec.rb
@@ -16,8 +16,8 @@ describe 'Administrator edit floor type' do
     condo = create :condo, name: 'Condomínio A'
     tower = create :tower, condo:, name: 'Torre A'
 
-    create :unit_type, description: 'Apartamento de 1 quarto'
-    create :unit_type, description: 'Apartamento de 2 quartos'
+    create :unit_type, condo:, description: 'Apartamento de 1 quarto'
+    create :unit_type, condo:, description: 'Apartamento de 2 quartos'
 
     login_as user, scope: :manager
     visit tower_path tower

--- a/spec/system/towers/administrator_register_floor_type_spec.rb
+++ b/spec/system/towers/administrator_register_floor_type_spec.rb
@@ -77,20 +77,6 @@ describe 'Administrator edit floor type' do
     expect(page).to have_content 'Defina o tipo de unidade para todas as unidades'
   end
 
-  it 'and update unit_types fraction' do
-    user = create :manager
-    condo = create :condo
-    first_unit_type = create :unit_type, description: 'Apartamento de 1 quarto', condo:, metreage: 50, fraction: nil
-    second_unit_type = create :unit_type, description: 'Apartamento de 2 quartos', condo:, metreage: 150
-    create(:tower, :with_four_units, floor_quantity: 5, condo:, unit_types: [first_unit_type, second_unit_type])
-
-    login_as user, scope: :manager
-    visit condo_unit_type_path(condo, first_unit_type)
-
-    expect(page).to have_content 'Fração Ideal: 2.5%'
-    expect(page).not_to have_content 'Não definido'
-  end
-
   context 'see a warning if registration is not complete' do
     it 'and go to floor type registration page after clicked the warning link' do
       user = create :manager

--- a/spec/system/unit_types/user_manage_unit_types_spec.rb
+++ b/spec/system/unit_types/user_manage_unit_types_spec.rb
@@ -17,14 +17,13 @@ describe 'User manage unit types' do
       end
       fill_in 'Descrição',	with: 'Apartamento de 2 quartos'
       fill_in 'Metragem',	with: '50'
-      fill_in 'Fração Ideal', with: '3'
       click_on 'Criar Tipo de unidade'
 
       expect(page).to have_content('Tipo de unidade cadastrado com sucesso')
       expect(current_path).to eq condo_unit_type_path(condo, UnitType.last)
       expect(page).to have_content('Descrição: Apartamento de 2 quartos')
       expect(page).to have_content('Metragem: 50.0m²')
-      expect(page).to have_content('Fração Ideal: 3.0%')
+      expect(page).to have_content('Fração Ideal: Não definida')
     end
 
     it 'with missing parameters' do
@@ -38,7 +37,6 @@ describe 'User manage unit types' do
       expect(page).to have_content('Erro ao cadastrar tipo de unidade')
       expect(page).to have_content('Descrição não pode ficar em branco')
       expect(page).to have_content('Metragem não pode ficar em branco')
-      expect(page).to have_content('Fração Ideal não pode ficar em branco')
     end
 
     it 'and access from navbar' do
@@ -58,23 +56,20 @@ describe 'User manage unit types' do
 
       expect(current_path).to eq new_condo_unit_type_path(condo)
       expect(page).to have_content('Cadastrar um novo tipo de unidade')
-      expect(page).to have_content('Fração Ideal (Valor em porcentagem)')
     end
 
-    it 'metreage and fraction cannot be zero or less' do
+    it 'metreage have to be bigger than 0' do
       condo = create(:condo, name: 'Condomínio dos rubinhos')
       user = create(:manager)
       login_as user, scope: :manager
       visit new_condo_unit_type_path(condo)
 
       fill_in 'Descrição',	with: 'Apartamento de 2 quartos'
-      fill_in 'Metragem',	with: '0'
-      fill_in 'Fração Ideal', with: '-1'
+      fill_in 'Metragem',	with: '-1'
       click_on 'Criar Tipo de unidade'
 
       expect(page).to have_content('Erro ao cadastrar tipo de unidade')
       expect(page).to have_content('Metragem deve ser maior que 0')
-      expect(page).to have_content('Fração Ideal deve ser maior que 0')
     end
   end
 
@@ -83,8 +78,9 @@ describe 'User manage unit types' do
       condo = create(:condo, name: 'Condomínio dos rubinhos')
       user = create(:manager)
       login_as user, scope: :manager
-      unit_type = UnitType.create!(description: 'Apartamento de 50 quartos', metreage: 5,
-                                   fraction: 3, condo_id: condo.id)
+      unit_type = UnitType.create!(description: 'Apartamento de 50 quartos',
+                                   metreage: 5,
+                                   condo_id: condo.id)
 
       visit condo_unit_type_path(condo, unit_type)
 
@@ -95,20 +91,20 @@ describe 'User manage unit types' do
       condo = create(:condo)
       user = create(:manager)
       login_as user, scope: :manager
-      unit_type = UnitType.create!(description: 'Apartamento de 50 quartos', metreage: 5,
-                                   fraction: 3, condo_id: condo.id)
+      unit_type = UnitType.create!(description: 'Apartamento de 50 quartos',
+                                   metreage: 5,
+                                   condo_id: condo.id)
 
       visit edit_condo_unit_type_path(condo, unit_type)
       fill_in 'Descrição',	with: 'Apartamento de 2 quartos'
       fill_in 'Metragem',	with: '50'
-      fill_in 'Fração Ideal',	with: '2'
       click_on 'Atualizar Tipo de unidade'
 
       expect(current_path).to eq condo_unit_type_path(condo, unit_type)
       expect(page).to have_content('Tipo de unidade atualizado com sucesso')
       expect(page).to have_content('Descrição: Apartamento de 2 quartos')
       expect(page).to have_content('Metragem: 50.0m²')
-      expect(page).to have_content('Fração Ideal: 2.0%')
+      expect(page).to have_content('Fração Ideal: Não definida')
     end
 
     it 'with missing params' do
@@ -120,14 +116,12 @@ describe 'User manage unit types' do
       visit edit_condo_unit_type_path(condo, unit_type)
       fill_in 'Descrição', with: ''
       fill_in 'Metragem',	with: ''
-      fill_in 'Fração Ideal',	with: ''
       click_on 'Atualizar Tipo de unidade'
 
       expect(current_path).to eq edit_condo_unit_type_path(condo, unit_type)
       expect(page).to have_content('Erro ao atualizar tipo de unidade')
       expect(page).to have_content('Descrição não pode ficar em branco')
       expect(page).to have_content('Metragem não pode ficar em branco')
-      expect(page).to have_content('Fração Ideal não pode ficar em branco')
     end
   end
 end

--- a/spec/system/unit_types/user_manage_unit_types_spec.rb
+++ b/spec/system/unit_types/user_manage_unit_types_spec.rb
@@ -87,7 +87,7 @@ describe 'User manage unit types' do
       expect(page).to have_link('Editar')
     end
 
-    it 'succesfully when is not related to a tower' do
+    it 'successfully when is not related to a tower' do
       condo = create(:condo)
       user = create(:manager)
       unit_type = UnitType.create!(description: 'Apartamento de 50 quartos',


### PR DESCRIPTION
### **Introdução**
Este PR refatora o calculo da fraçao ideal, para que o mesmo seja feito sempre que uma torre for atualizada, assim garantindo que a soma das fracoes ideais de um condominio seja 100%.
Durante a implementacao foi encontrado um bug na listagem de tipos de unidade, aonde as opcoes nao estavam referentes ao condominio em questao

### **Objetivos**
- Automatizar o calculo da fraçao ideal dos tipos de unidade de um condominio após a atualizacao de uma torre e após atualizar metragem de um tipo de unidade vinculado a uma torre
- Alterado o formulario de cadastro de tipos de unidade para nao receber a fraçao ideal.
- Caso um tipo de unidade nao possua unidades vinculadas sua fraçao ideal retornara "Não definido"
- Definido restricao no formulario de atualizar pavimento tipo, para so exibir tipos de unidade do condominio atual

### **Detalhes**
Tela de cadastro de um tipo de unidade
![image](https://github.com/TreinaDev/condominions/assets/90734901/50acd551-5f2c-462c-9cd1-b55b9fd25655)

Tela do tipo de unidade antes de ser vinculada a uma torre
![image](https://github.com/TreinaDev/condominions/assets/90734901/16850338-8cd1-4179-a1ec-bd2c5ee9f23e)

Tela do tipo de unidade após ser vinculada a uma torre de 10 andares com 1 unidade/andar:
![image](https://github.com/TreinaDev/condominions/assets/90734901/f164f973-d698-4006-91aa-96218f696885)


resolve issue: #78 
