### PR TITLE
Padronizar e melhorar estilização de telas

### DIFF
--- a/app/controllers/floors_controller.rb
+++ b/app/controllers/floors_controller.rb
@@ -15,7 +15,6 @@ class FloorsController < ApplicationController
 
   def set_breadcrumbs_for_details
     add_breadcrumb @tower.condo.name.to_s, condo_path(@tower.condo)
-    add_breadcrumb I18n.t('breadcrumb.tower.index'), condo_towers_path(@tower.condo)
     add_breadcrumb @tower.name.to_s, @tower
     add_breadcrumb @floor.print_identifier
   end

--- a/app/controllers/unit_types_controller.rb
+++ b/app/controllers/unit_types_controller.rb
@@ -57,7 +57,6 @@ class UnitTypesController < ApplicationController
   def set_breadcrumb_for_details
     @condo = @unit_type.condo
     add_breadcrumb @condo.name, @condo
-    add_breadcrumb I18n.t('breadcrumb.unit_type.index'), condo_unit_types_path(@condo)
     add_breadcrumb @unit_type.description, @unit_type
   end
 

--- a/app/views/common_areas/edit.html.erb
+++ b/app/views/common_areas/edit.html.erb
@@ -1,23 +1,32 @@
-<h1>Editar área comum</h1>
-
 <%= render 'shared/errors', model: @common_area %>
+<div class='bg-white rounded-5 py-4 px-5 shadow'>
+  <h1>Editar área comum</h1>
 
-<%= form_with model: @common_area do |f| %>
-  <div class="mb-3 row">
-    <%= f.label :name, class: 'col-sm-2 col-form-label' %>
-    <div class="col-sm-10"><%= f.text_field :name, class: 'form-control' %></div>
-  </div>
-  <div class="mb-3 row">
-    <%= f.label :description, class: 'col-sm-2 col-form-label' %>
-    <div class="col-sm-10"><%= f.text_area :description, class: 'form-control' %></div>
-  </div>
-  <div class="mb-3 row">
-    <%= f.label :max_occupancy, class: 'col-sm-2 col-form-label' %>
-    <div class="col-sm-10"><%= f.number_field :max_occupancy, class: 'form-control' %></div>
-  </div>
-  <div class="mb-3 row">
-    <%= f.label :rules, class: 'col-sm-2 col-form-label' %>
-    <div class="col-sm-10"><%= f.text_area :rules, class: 'form-control' %></div>
-  </div>
-  <%= f.submit 'Salvar', class: 'btn btn-primary' %>
-<% end %>
+  <%= form_with model: @common_area do |f| %>
+    <div class="form-row row p-2">
+      <div class="form-group col-md-6 pe-3 mb-2">
+        <%= f.label :name %>
+        <%= f.text_field :name, class: 'form-control' %>
+      </div>
+
+      <div class="form-group col-md-6 pe-3 mb-2">
+        <%= f.label :max_occupancy%>
+        <%= f.number_field :max_occupancy, class: 'form-control' %>
+      </div>
+
+      <div class="form-group col-md-6 pe-3 mb-2">
+        <%= f.label :description %>
+        <%= f.text_area :description, class: 'form-control' %>
+      </div>
+
+      <div class="form-group col-md-6 pe-3 mb-2">
+        <%= f.label :rules %>
+        <%= f.text_area :rules, class: 'form-control' %>
+      </div>
+    </div>
+
+    <div class="d-flex justify-content-center">
+      <%= f.submit 'Salvar', class: 'btn btn-dark rounded-pill px-4 mt-3' %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/common_areas/index.html.erb
+++ b/app/views/common_areas/index.html.erb
@@ -1,1 +1,0 @@
-<h1>Áreas Comuns</h1>

--- a/app/views/common_areas/new.html.erb
+++ b/app/views/common_areas/new.html.erb
@@ -1,23 +1,33 @@
-<h1 class="mb-4">Cadastrar nova área comum</h1>
-
 <%= render 'shared/errors', model: @common_area %>
 
-<%= form_with(model: [@condo, @common_area], class: 'text-center') do |f| %>
-  <div class="mb-3 row">
-    <%= f.label :name, class: 'col-sm-2 col-form-label' %>
-    <div class="col-sm-10"><%= f.text_field :name, class: 'form-control' %></div>
-  </div>
-  <div class="mb-3 row">
-    <%= f.label :description, class: 'col-sm-2 col-form-label' %>
-    <div class="col-sm-10"><%= f.text_area :description, class: 'form-control' %></div>
-  </div>
-  <div class="mb-3 row">
-    <%= f.label :max_occupancy, class: 'col-sm-2 col-form-label' %>
-    <div class="col-sm-10"><%= f.number_field :max_occupancy, class: 'form-control' %></div>
-  </div>
-  <div class="mb-3 row">
-    <%= f.label :rules, class: 'col-sm-2 col-form-label' %>
-    <div class="col-sm-10"><%= f.text_area :rules, class: 'form-control' %></div>
-  </div>
-  <%= f.submit 'Salvar', class: 'btn btn-primary' %>
-<% end %>
+<div class='bg-white rounded-5 py-3 px-5 shadow'>
+  <h1>Cadastrar nova área comum</h1>
+
+  <%= form_with model: [@condo, @common_area] do |f| %>
+    <div class="form-row row p-2">
+      <div class="form-group col-md-6 pe-3 mb-2">
+        <%= f.label :name %>
+        <%= f.text_field :name, class: 'form-control' %>
+      </div>
+
+      <div class="form-group col-md-6 pe-3 mb-2">
+        <%= f.label :max_occupancy%>
+        <%= f.number_field :max_occupancy, class: 'form-control' %>
+      </div>
+
+      <div class="form-group col-md-6 pe-3 mb-2">
+        <%= f.label :description %>
+        <%= f.text_area :description, class: 'form-control' %>
+      </div>
+
+      <div class="form-group col-md-6 pe-3 mb-2">
+        <%= f.label :rules %>
+        <%= f.text_area :rules, class: 'form-control' %>
+      </div>
+    </div>
+
+    <div class="d-flex justify-content-center">
+      <%= f.submit 'Salvar', class: 'btn btn-dark rounded-pill px-4 mt-3' %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/common_areas/show.html.erb
+++ b/app/views/common_areas/show.html.erb
@@ -1,7 +1,9 @@
-<h1 class="mb-3"><%= @common_area.name %></h1>
+<div class='bg-white rounded-5 py-4 px-5 shadow'>
+  <h1 class="mb-3"><%= @common_area.name %></h1>
 
-<p><strong>Descrição:</strong> <%= @common_area.description %></p>
-<p><strong>Capacidade Máxima:</strong> <%= @common_area.max_occupancy %> pessoas</p>
-<p><strong>Regras de Uso:</strong> <%= @common_area.rules %></p>
+  <p><strong>Descrição:</strong> <%= @common_area.description %></p>
+  <p><strong>Capacidade Máxima:</strong> <%= @common_area.max_occupancy %> pessoas</p>
+  <p><strong>Regras de Uso:</strong> <%= @common_area.rules %></p>
 
-<%= link_to 'Editar', edit_common_area_path(@common_area), class: 'btn btn-primary' %>
+  <%= link_to 'Editar', edit_common_area_path(@common_area), class: 'btn btn-dark rounded-pill px-4' %>
+</div>

--- a/app/views/condos/_form.html.erb
+++ b/app/views/condos/_form.html.erb
@@ -1,29 +1,30 @@
-<%= render "shared/errors", model: @condo %>
-
 <%= form_with(model: @condo) do |f| %>
   <div class="form-row d-flex p-2">
     <div class="form-group col-md-6 pe-3">
       <%= f.label :name %>
       <%= f.text_field :name, class:"form-control" %>
     </div>
+    
     <div class="form-group col-md-6" data-controller="mask">
       <%= f.label :registration_number %>
       <%= f.text_field :registration_number, class:"form-control", placeholder: "00.111.222/3333-44" ,
           maxlength: "18", :'data-action' => 'keyup->mask#RegistrationNumberPressed' %>
     </div>
   </div>
+
   <div>
     <%= f.fields_for :address, @condo.address || Address.new do |address_f| %>
-    
       <div class="form-row d-flex p-2">
         <div class="form-group col-md-6 pe-3">
           <%= address_f.label :public_place %>
           <%= address_f.text_field :public_place, class:"form-control" %>
         </div>
+
         <div class="form-group col-md-2 pe-3">
           <%= address_f.label :number %>
           <%= address_f.text_field :number, class:"form-control" %>
         </div>
+
         <div class="form-group col-md-4 pe-3">
           <%= address_f.label :neighborhood %>
           <%= address_f.text_field :neighborhood, class:"form-control" %>
@@ -35,11 +36,13 @@
           <%= address_f.label :city %>
           <%= address_f.text_field :city, class:"form-control"  %>
         </div>
+
         <div class="form-group col-md-2 pe-3">
           <%= address_f.label :state %>
           <%= address_f.select :state, options_for_select(Address::STATES), {}, 
           class:"form-control form-select" %>
         </div>
+
         <div class="form-group col-md-4 pe-3" data-controller="mask">
           <%= address_f.label :zip %>
           <%= address_f.text_field :zip, class:"form-control", placeholder: "12345-678" ,
@@ -47,9 +50,7 @@
         </div>
       </div>
     <% end %>
-    <%= f.submit 'Salvar', class:"btn btn-dark" %>
 
+    <%= f.submit 'Salvar', class:"btn btn-dark rounded-pill px-4 mt-3" %>
   </div>
-
-  
 <% end %>

--- a/app/views/condos/_form.html.erb
+++ b/app/views/condos/_form.html.erb
@@ -51,6 +51,8 @@
       </div>
     <% end %>
 
-    <%= f.submit 'Salvar', class:"btn btn-dark rounded-pill px-4 mt-3" %>
+    <div class="d-flex justify-content-center">
+      <%= f.submit 'Salvar', class:"btn btn-dark rounded-pill px-4 mt-3" %>
+    </div>
   </div>
 <% end %>

--- a/app/views/condos/edit.html.erb
+++ b/app/views/condos/edit.html.erb
@@ -1,3 +1,5 @@
-<h1>Editar Condomínio:</h1>
-
-<%= render 'form' %>
+<%= render "shared/errors", model: @condo %>
+<section class="bg-white rounded-5 py-4 px-5 shadow">
+  <h1>Editar Condomínio</h1>
+  <%= render 'form' %>
+</section>

--- a/app/views/condos/new.html.erb
+++ b/app/views/condos/new.html.erb
@@ -1,3 +1,5 @@
-<h1>Cadastre um novo Condomínio:</h1>
-
-<%= render 'form' %>
+<%= render "shared/errors", model: @condo %>
+<section class="bg-white rounded-5 py-4 px-5 shadow">
+  <h1>Cadastre um novo Condomínio</h1>
+  <%= render 'form' %>
+</section>

--- a/app/views/floors/show.html.erb
+++ b/app/views/floors/show.html.erb
@@ -1,15 +1,15 @@
-<h1><%= @tower.name %></h1>
+<section class="bg-white rounded-5 py-4 px-5 shadow">
+  <h1><%= @floor.print_identifier %></h1>
 
-<h2><%= @floor.print_identifier %></h2>
-
-<% @floor.return_unit_types.each_with_index do |unit_type, index| %>
-  <div id = <%= "unit-type-#{index + 1}" %>>
-    <h3><%= unit_type.description %></h3>
-    
-    <% @floor.units.each do |unit| %>
-      <% if unit.unit_type == unit_type %>
-        <p><%= unit.print_identifier %></p>
+  <% @floor.return_unit_types.each_with_index do |unit_type, index| %>
+    <div id = <%= "unit-type-#{index + 1}" %>>
+      <h2><%= unit_type.description %></h2>
+      
+      <% @floor.units.each do |unit| %>
+        <% if unit.unit_type == unit_type %>
+          <p><%= unit.print_identifier %></p>
+        <% end %>
       <% end %>
-    <% end %>
-  </div>
-<% end %>
+    </div>
+  <% end %>
+</section>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,16 +1,18 @@
-<h1 class="mb-3">Condomínios</h1>
+<section>
+  <h1 class="mb-3">Condomínios</h1>
 
-<div id="condos-list">
+  <div id="condos-list">
     <% if @condos.empty? %>
-        <p>Não existem condomínios cadastrados no sistema.</p>
+      <p>Não existem condomínios cadastrados no sistema.</p>
     <% else %>
-        <% @condos.each do |condo| %>
-            <%= link_to condo_path(condo.id), class: 'link-underline link-underline-opacity-0' do %>
-            <div class="bg-warning-subtle py-3 px-5 text-black mb-3 rounded-4 shadow-sm">
-                <h2><%= condo.name %></h2>
-                <h6>Endereço: <%= condo.full_address %></h6>
-            </div>
-            <% end %>
-        <% end %>  
+      <% @condos.each do |condo| %>
+        <%= link_to condo_path(condo.id), class: 'link-underline link-underline-opacity-0' do %>
+          <div class="bg-warning-subtle py-3 px-5 text-black mb-3 rounded-4 shadow-sm">
+            <h2><%= condo.name %></h2>
+            <p>Endereço: <%= condo.full_address %></p>
+          </div>
+        <% end %>
+      <% end %>  
     <% end %>
-</div>
+  </div>
+</section>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="pt-BR">
   <head>
     <title>CondoMinions</title>
     <%= csrf_meta_tags %>

--- a/app/views/managers/new.html.erb
+++ b/app/views/managers/new.html.erb
@@ -1,27 +1,34 @@
-<h1 class="mb-4">Cadastrar Novo Administrador</h1>
-
 <%= render 'shared/errors', model: @manager %>
 
-<%= form_with(model: @manager, class: 'text-center') do |f| %>
-  <div class="mb-3 row">
-    <%= f.label :user_image, class: 'col-sm-2 col-form-label' %>
-    <div class="col-sm-10"><%= f.file_field :user_image, class: 'form-control' %></div>
-  </div>
-  <div class="mb-3 row">
-    <%= f.label :full_name, class: 'col-sm-2 col-form-label' %>
-    <div class="col-sm-10"><%= f.text_field :full_name, class: 'form-control' %></div>
-  </div>
-  <div class="mb-3 row" data-controller="mask">
-    <%= f.label :registration_number, class: 'col-sm-2 col-form-label' %>
-    <div class="col-sm-10"><%= f.text_field :registration_number, class: 'form-control', maxlength: "14", :'data-action' => 'keyup -> mask#registrationNumberFormated' %></div>
-  </div>
-  <div class="mb-3 row">
-    <%= f.label :email, class: 'col-sm-2 col-form-label' %>
-    <div class="col-sm-10"><%= f.email_field :email, class: 'form-control' %></div>
-  </div>
-  <div class="mb-3 row">
-    <%= f.label :password, class: 'col-sm-2 col-form-label' %>
-    <div class="col-sm-10"><%= f.password_field :password, class: 'form-control' %></div>
-  </div>
-  <%= f.submit 'Cadastrar', class: 'btn btn-primary' %>
-<% end %>
+<div class='bg-white rounded-5 py-4 px-5 shadow'>
+  <h1>Cadastrar Novo Administrador</h1>
+
+  <%= form_with model: @manager do |f| %>
+    <div class="form-row row p-2">
+      <div class="form-group col-md-12 pe-3 mb-2">
+        <%= f.label :user_image%>
+        <%= f.file_field :user_image, class: 'form-control' %>
+      </div>
+      <div class="form-group col-md-6 pe-3 mb-2">
+        <%= f.label :full_name %>
+        <%= f.text_field :full_name, class: 'form-control' %>
+      </div>
+      <div class="form-group col-md-6 pe-3 mb-2" data-controller="mask">
+        <%= f.label :registration_number %>
+        <%= f.text_field :registration_number, class: 'form-control', maxlength: "14", :'data-action' => 'keyup -> mask#registrationNumberFormated' %>
+      </div>
+      <div class="form-group col-md-6 pe-3 mb-2">
+        <%= f.label :email %>
+        <%= f.email_field :email, class: 'form-control' %>
+      </div>
+      <div class="form-group col-md-6 pe-3 mb-2">
+        <%= f.label :password %>
+        <%= f.password_field :password, class: 'form-control' %>
+      </div>
+    </div>
+    
+    <div class="d-flex justify-content-center">
+      <%= f.submit 'Cadastrar', class: 'btn btn-dark rounded-pill px-4 mt-3' %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/managers/passwords/edit.html.erb
+++ b/app/views/managers/passwords/edit.html.erb
@@ -23,6 +23,6 @@
   <% end %>
 
   <div class="d-flex justify-content-center mt-3">
-    <%= render "residents/shared/links" %>
+    <%= render "managers/shared/links" %>
   </div>
 </div>

--- a/app/views/managers/passwords/new.html.erb
+++ b/app/views/managers/passwords/new.html.erb
@@ -1,18 +1,23 @@
-<h2>Esqueceu sua senha?</h2>
+<div class='bg-white rounded-5 py-4 px-5 shadow'>
+  <h2 class="text-center">Esqueceu sua senha?</h2>
 
-<div class="mt-3 text-center">
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "managers/shared/error_messages", resource: resource %>
+  <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+    <%= render "managers/shared/error_messages", resource: resource %>
+    
+    <div class="form-row row p-2">
+      <div class="form-group col-md-12 pe-3 mb-2">
+        <%= f.label :email %>
+        <%= f.email_field :email, autofocus: true, autocomplete: "email", class: 'form-control' %>
+      </div>
+    </div>
 
-  <div class="field mb-2 row">
-    <%= f.label :email, class: 'col-sm-2 col-form-label' %><br />
-    <div class="col-sm-10"><%= f.email_field :email, autofocus: true, autocomplete: "email", class: 'form-control' %></div>
+    <div class="actions d-flex justify-content-center">
+      <%= f.submit "Envie-me as instruções para redefinição de senha", class: 'btn btn-dark rounded-pill px-4 mt-1' %>
+    </div>
+  <% end %>
+  <div>
+
+  <div class="d-flex justify-content-center mt-2">
+    <%= render "managers/shared/links" %>
   </div>
-
-  <div class="actions">
-    <%= f.submit "Envie-me as instruções\n para redefinição de senha", class: 'btn btn-success my-3' %>
-  </div>
-<% end %>
-<div>
-
-<%= render "managers/shared/links" %>
+</div>

--- a/app/views/managers/sessions/new.html.erb
+++ b/app/views/managers/sessions/new.html.erb
@@ -1,29 +1,33 @@
-<h2>Faça login para continuar</h2>
+<div class='bg-white rounded-5 py-4 px-5 shadow'>
+  <h2 class="text-center">Faça login para continuar</h2>
 
-<div class="mt-3 text-center">
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="field mb-2 row">
-    <%= f.label :email, class: 'col-sm-2 col-form-label' %>
-    <div class="col-sm-10"><%= f.email_field :email, autofocus: true, autocomplete: "email", class: 'form-control' %></div>
-  </div>
+  <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+    <div class="form-row row p-2">
+      <div class="form-group col-md-12 pe-3 mb-2">
+        <%= f.label :email %>
+        <%= f.email_field :email, autofocus: true, autocomplete: "email", class: 'form-control' %>
+      </div>
 
-  <div class="field mb-2 row">
-    <%= f.label :password, class: 'col-sm-2 col-form-label'%>
-    <div class="col-sm-10"><%= f.password_field :password, autocomplete: "current-password", class: 'form-control' %></div>
-  </div>
+      <div class="form-group col-md-12 pe-3 mb-2">
+        <%= f.label :password %>
+        <%= f.password_field :password, autocomplete: "current-password", class: 'form-control' %>
+      </div>
 
-  <% if devise_mapping.rememberable? %>
-    <div class="field my-4">
-      <%= f.check_box :remember_me, class: 'form-check-input' %>
-      <%= f.label :remember_me, class: 'form-check-label' %>
+      <% if devise_mapping.rememberable? %>
+        <div class="form-check form-switch d-flex justify-content-center py-2">
+          <%= f.check_box :remember_me, class: 'form-check-input' %>
+          <%= f.label :remember_me, class: 'ms-1 form-check-label' %>
+        </div>
+      <% end %>
+    </div>
+
+    <div class="actions d-flex justify-content-center">
+      <%= f.submit "Entrar", class: 'btn btn-dark rounded-pill px-4 mt-1' %>
     </div>
   <% end %>
 
-  <div class="actions">
-    <%= f.submit "Entrar", class: 'btn btn-primary my-2' %>
+  <div class="d-flex justify-content-center mt-3">
+    <%= render "managers/shared/links" %>
   </div>
-<% end %>
-
-<%= render "managers/shared/links" %>
 </div>
 

--- a/app/views/managers/shared/_links.html.erb
+++ b/app/views/managers/shared/_links.html.erb
@@ -1,5 +1,5 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to "Entrar", new_session_path(resource_name), class: 'btn btn-outline-dark' %>
+  <%= link_to "Entrar", new_session_path(resource_name), class: 'btn btn-dark rounded-pill px-4' %>
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
@@ -7,7 +7,7 @@
 <% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Esqueceu sua senha?", new_password_path(resource_name), class: 'btn btn-outline-dark' %><br />
+  <%= link_to "Esqueceu sua senha?", new_password_path(resource_name), class: 'btn btn-dark rounded-pill px-4' %><br />
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>

--- a/app/views/residents/confirm.html.erb
+++ b/app/views/residents/confirm.html.erb
@@ -1,56 +1,62 @@
-<h1 class="mb-4">Confirme o seu cadastro</h1>
-
 <%= render 'shared/errors', model: @resident %>
 
-<%= form_with(model: @resident, class: 'text-center') do |f| %>
-  <div class="mb-3 row">
-    <%= f.label :full_name, class: 'col-sm-2 col-form-label' %>
-    <div class="col-sm-10"><%= f.text_field :full_name, class: 'form-control', disabled: true %></div>
-  </div>
-  <div class="mb-3 row", data-controller="mask">
-    <%= f.label :registration_number, class: 'col-sm-2 col-form-label' %>
-    <div class="col-sm-10"><%= f.text_field :registration_number, class: 'form-control', disabled: true  %></div>
-  </div>
-  <div class="mb-3 row">
-    <%= f.label :email, class: 'col-sm-2 col-form-label' %>
-    <div class="col-sm-10"><%= f.text_field :email, class: 'form-control', disabled: true %></div>
-  </div>
-  <div class="mb-3 row">
-    <%= f.label :resident_type, class: 'col-sm-2 col-form-label' %>
-    <div class="col-sm-10"><%= f.text_field :resident_type, class: 'form-control', disabled: true, value: "#{I18n.t(@resident.resident_type)}" %></div>
-  </div>
+<div class='bg-white rounded-5 py-4 px-5 shadow'>
+  <h1>Confirme o seu cadastro</h1>
 
-  <div class="mb-3 row">
-    <%= f.label :condo_id, class: 'col-sm-2 col-form-label' %>
-    <div class="col-sm-10"><%= f.text_field :condo_id, class: 'form-control', disabled: true, value: "#{@resident.condo.name}"  %></div> 
-  </div>
-  <div class="mb-3 row">
-    <%= f.label :tower_id, class: 'col-sm-2 col-form-label' %>
-    <div class="col-sm-10"><%= f.text_field :tower_id, class: 'form-control', disabled: true, value: "#{@resident.tower.name}"  %></div> 
-  </div>
-  <div class="mb-3 row">
-    <%= f.label :floor, class: 'col-sm-2 col-form-label' %>
-    <div class="col-sm-10"><%= f.text_field :floor, class: 'form-control', disabled: true, value: "#{@resident.floor.identifier}"  %></div> 
-  </div>
-  <div class="mb-3 row">
-    <%= f.label :unit, class: 'col-sm-2 col-form-label' %>
-    <div class="col-sm-10"><%= f.text_field :unit, class: 'form-control', disabled: true, value: "#{@resident.unit.short_identifier}" %></div> 
-  </div>
+  <%= form_with model: @resident do |f| %>
+    <div class="form-row row p-2">
+      <div class="form-group col-md-6 pe-3 mb-2">
+        <%= f.label :full_name %>
+        <%= f.text_field :full_name, class: 'form-control', disabled: true %>
+      </div>
+      <div class="form-group col-md-6 pe-3 mb-2", data-controller="mask">
+        <%= f.label :registration_number %>
+        <%= f.text_field :registration_number, class: 'form-control', disabled: true  %>
+      </div>
+      <div class="form-group col-md-6 pe-3 mb-2">
+        <%= f.label :email %>
+        <%= f.text_field :email, class: 'form-control', disabled: true %>
+      </div>
+      <div class="form-group col-md-6 pe-3 mb-2">
+        <%= f.label :resident_type %>
+        <%= f.text_field :resident_type, class: 'form-control', disabled: true, value: "#{I18n.t(@resident.resident_type)}" %>
+      </div>
 
-  <h2>Campos editáveis: </h2>
+      <div class="form-group col-md-12 pe-3 mb-2">
+        <%= f.label :condo_id %>
+        <%= f.text_field :condo_id, class: 'form-control', disabled: true, value: "#{@resident.condo.name}" %>
+      </div>
+      <div class="form-group col-md-12 pe-3 mb-2">
+        <%= f.label :tower_id %>
+        <%= f.text_field :tower_id, class: 'form-control', disabled: true, value: "#{@resident.tower.name}" %> 
+      </div>
+      <div class="form-group col-md-12 pe-3 mb-2">
+        <%= f.label :floor %>
+        <%= f.text_field :floor, class: 'form-control', disabled: true, value: "#{@resident.floor.identifier}" %>
+      </div>
+      <div class="form-group col-md-12 pe-3 mb-2">
+        <%= f.label :unit %>
+        <%= f.text_field :unit, class: 'form-control', disabled: true, value: "#{@resident.unit.short_identifier}" %>
+      </div>
 
-  <div class="mb-3 row">
-    <%= f.label :user_image, class: 'col-sm-2 col-form-label' %>
-    <div class="col-sm-10"><%= f.file_field :user_image, class: 'form-control' %></div>
-  </div>
-  <div class="mb-3 row">
-    <%= f.label :password, class: 'col-sm-2 col-form-label' %>
-    <div class="col-sm-10"><%= f.password_field :password, class: 'form-control' %></div>
-  </div>
-  <div class="mb-3 row">
-    <%= f.label :password_confirmation, class: 'col-sm-2 col-form-label' %>
-    <div class="col-sm-10"><%= f.password_field :password_confirmation, class: 'form-control' %></div>
-  </div>
+      <h2>Campos editáveis: </h2>
 
-  <%= f.submit "Confirmar Dados", class: 'btn btn-primary' %>
-<% end %>
+      <div class="form-group col-md-12 pe-3 mb-2">
+        <%= f.label :user_image %>
+        <%= f.file_field :user_image, class: 'form-control' %>
+      </div>
+      <div class="form-group col-md-6 pe-3 mb-2">
+        <%= f.label :password %>
+        <%= f.password_field :password, class: 'form-control' %>
+      </div>
+      <div class="form-group col-md-6 pe-3 mb-2">
+        <%= f.label :password_confirmation %>
+        <%= f.password_field :password_confirmation, class: 'form-control' %>
+      </div>
+    </div>
+
+    <div class="d-flex justify-content-center">
+      <%= f.submit "Confirmar Dados", class: 'btn btn-dark rounded-pill px-4 mt-3' %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/residents/edit_photo.html.erb
+++ b/app/views/residents/edit_photo.html.erb
@@ -1,15 +1,21 @@
-<h1>Editar Foto</h1>
+<div class='bg-white rounded-5 py-4 px-5 shadow'>
+  <h1>Editar Foto</h1>
 
-<% if @resident.user_image.attached? %>
-  <div class="current-photo d-flex justify-content-center mb-4">
-    <%= image_tag @resident.user_image, alt: 'Current Image', style: "width: 200px; height: 200px" %>
-  </div>
-<% end %>
+  <% if @resident.user_image.attached? %>
+    <div class="current-photo d-flex justify-content-center mb-4">
+      <%= image_tag @resident.user_image, alt: 'Current Image', style: "width: 200px; height: 200px" %>
+    </div>
+  <% end %>
 
-<%= form_with(model: @resident, url: update_photo_resident_path(@resident), method: 'patch', class: 'text-center') do |f| %>
-  <div class="mb-3 row">
-    <%= f.label :user_image, class: 'col-sm-2 col-form-label' %>
-    <div class="col-sm-10"><%= f.file_field :user_image, class: 'form-control' %></div>
-  </div>
-  <%= f.submit 'Enviar', class: 'btn btn-primary' %>
-<% end %>
+  <%= form_with(model: @resident, url: update_photo_resident_path(@resident), method: 'patch') do |f| %>
+    <div class="form-row row p-2">
+      <div class="form-group col-md-12 mb-2">
+        <%= f.label :user_image %>
+        <%= f.file_field :user_image, class: 'form-control' %>
+      </div>
+    </div>
+    <div class="d-flex justify-content-center">
+      <%= f.submit 'Enviar', class: 'btn btn-dark rounded-pill px-4 mt-3' %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/residents/new.html.erb
+++ b/app/views/residents/new.html.erb
@@ -1,43 +1,49 @@
-<h1 class="mb-4">Cadastrar Morador</h1>
-
 <%= render 'shared/errors', model: @resident %>
 
-<%= form_with(model: @resident, class: 'text-center') do |f| %>
-  <div class="mb-3 row">
-    <%= f.label :full_name, class: 'col-sm-2 col-form-label' %>
-    <div class="col-sm-10"><%= f.text_field :full_name, class: 'form-control' %></div>
-  </div>
-  <div class="mb-3 row", data-controller="mask">
-    <%= f.label :registration_number, class: 'col-sm-2 col-form-label' %>
-    <div class="col-sm-10"><%= f.text_field :registration_number, class: 'form-control', maxlength: "14", :'data-action' => 'keyup -> mask#registrationNumberFormated'  %></div>
-  </div>
-  <div class="mb-3 row">
-    <%= f.label :email, class: 'col-sm-2 col-form-label' %>
-    <div class="col-sm-10"><%= f.email_field :email, class: 'form-control' %></div>
-  </div>
-  <div class="mb-3 row">
-    <%= f.label :resident_type, class: 'col-sm-2 col-form-label' %>
-    <div class="col-sm-10"><%= f.select :resident_type, Resident.resident_types.keys.map { |type| [I18n.t(type).capitalize, type] }, {}, class: 'form-control form-select' %></div>
-  </div>
+<div class='bg-white rounded-5 py-4 px-5 shadow'>
+  <h1>Cadastrar Morador</h1>
 
-  <div data-controller="resident">
-    <div class="mb-3 row">
-      <%= f.label :condo_id, class: 'col-sm-2 col-form-label' %>
-      <div class="col-sm-10"><%= f.collection_select :condo_id, @condos, :id, :name, {}, :'data-resident-target' => "condo", :'data-action' => "change->resident#changeCondo", class: 'form-control form-select' %></div> 
-    </div>
-    <div class="mb-3 row">
-      <%= f.label :tower_id, class: 'col-sm-2 col-form-label' %>
-      <div class="col-sm-10"><%= f.collection_select :tower_id, {}, {}, {}, {}, :'data-resident-target' => "tower", :'data-action' => "change->resident#changeTower", class: 'form-control form-select' %></div> 
-    </div>
-    <div class="mb-3 row">
-      <%= f.label :floor, class: 'col-sm-2 col-form-label' %>
-      <div class="col-sm-10"><%= f.collection_select :floor, {}, {}, {}, {}, :'data-resident-target' => "floor", class: 'form-control form-select' %></div>
-    </div>
-    <div class="mb-3 row">
-      <%= f.label :unit, class: 'col-sm-2 col-form-label' %>
-      <div class="col-sm-10"><%= f.collection_select :unit, {}, {}, {}, {}, :'data-resident-target' => "unit", class: 'form-control form-select' %></div>
-    </div>
-  </div>
+  <%= form_with model: @resident  do |f| %>
+    <div class="form-row row p-2">
+      <div class="form-group col-md-6 pe-3 mb-2">
+        <%= f.label :full_name %>
+        <%= f.text_field :full_name, class: 'form-control' %>
+      </div>
+      <div class="form-group col-md-6 pe-3 mb-2", data-controller="mask">
+        <%= f.label :registration_number %>
+        <%= f.text_field :registration_number, class: 'form-control', maxlength: "14", :'data-action' => 'keyup -> mask#registrationNumberFormated'  %>
+      </div>
+      <div class="form-group col-md-6 pe-3 mb-2">
+        <%= f.label :email %>
+        <%= f.email_field :email, class: 'form-control' %>
+      </div>
+      <div class="form-group col-md-6 pe-3 mb-2">
+        <%= f.label :resident_type %>
+        <%= f.select :resident_type, Resident.resident_types.keys.map { |type| [I18n.t(type).capitalize, type] }, {}, class: 'form-control form-select' %>
+      </div>
 
-  <%= f.submit "Enviar", class: 'btn btn-primary' %>
-<% end %>
+      <div data-controller="resident">
+        <div class="form-group col-md-12 mb-2">
+          <%= f.label :condo_id %>
+          <%= f.collection_select :condo_id, @condos, :id, :name, {}, :'data-resident-target' => "condo", :'data-action' => "change->resident#changeCondo", class: 'form-control form-select' %>
+        </div>
+        <div class="form-group col-md-12 mb-2">
+          <%= f.label :tower_id %>
+          <%= f.collection_select :tower_id, {}, {}, {}, {}, :'data-resident-target' => "tower", :'data-action' => "change->resident#changeTower", class: 'form-control form-select' %>
+        </div>
+        <div class="form-group col-md-12 mb-2">
+          <%= f.label :floor %>
+          <%= f.collection_select :floor, {}, {}, {}, {}, :'data-resident-target' => "floor", class: 'form-control form-select' %>
+        </div>
+        <div class="form-group col-md-12 mb-2">
+          <%= f.label :unit %>
+          <%= f.collection_select :unit, {}, {}, {}, {}, :'data-resident-target' => "unit", class: 'form-control form-select' %>
+        </div>
+      </div>
+    </div>
+
+    <div class="d-flex justify-content-center">
+      <%= f.submit "Enviar", class: 'btn btn-dark rounded-pill px-4 mt-1' %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/residents/passwords/new.html.erb
+++ b/app/views/residents/passwords/new.html.erb
@@ -1,16 +1,22 @@
-<h2>Esqueceu sua senha?</h2>
+<div class='bg-white rounded-5 py-4 px-5 shadow'>
+  <h2 class="text-center">Esqueceu sua senha?</h2>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "residents/shared/error_messages", resource: resource %>
+  <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+    <%= render "residents/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <div class="form-row row p-2">
+      <div class="form-group col-md-12 pe-3 mb-2">
+        <%= f.label :email %><br />
+        <%= f.email_field :email, autofocus: true, autocomplete: "email", class: 'form-control' %>
+      </div>
+    </div>
+
+    <div class="actions d-flex justify-content-center">
+      <%= f.submit "Envie-me as instruções para redefinição de senha", class: 'btn btn-dark rounded-pill px-4 mt-1' %>
+    </div>
+  <% end %>
+
+  <div class="d-flex justify-content-center mt-2">
+    <%= render "residents/shared/links" %>
   </div>
-
-  <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
-  </div>
-<% end %>
-
-<%= render "residents/shared/links" %>
+</div>

--- a/app/views/residents/sessions/new.html.erb
+++ b/app/views/residents/sessions/new.html.erb
@@ -1,28 +1,32 @@
-<h2>Faça login para continuar</h2>
+<div class='bg-white rounded-5 py-4 px-5 shadow'>
+  <h2 class="text-center">Faça login para continuar</h2>
 
-<div class="mt-3 text-center">
   <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-    <div class="field mb-2 row">
-      <%= f.label :email, class: 'col-sm-2 col-form-label' %>
-      <div class="col-sm-10"><%= f.email_field :email, autofocus: true, autocomplete: "email", class: 'form-control' %></div>
-    </div>
-
-    <div class="field mb-2 row">
-      <%= f.label :password, class: 'col-sm-2 col-form-label' %>
-      <div class="col-sm-10"><%= f.password_field :password, autocomplete: "current-password", class: 'form-control' %></div>
-    </div>
-
-    <% if devise_mapping.rememberable? %>
-      <div class="field my-4">
-        <%= f.check_box :remember_me, class: 'form-check-input' %>
-        <%= f.label :remember_me, class: 'form-check-label' %>
+    <div class="form-row row p-2">
+      <div class="form-group col-md-12 pe-3 mb-2">
+        <%= f.label :email %>
+        <%= f.email_field :email, autofocus: true, autocomplete: "email", class: 'form-control' %>
       </div>
-    <% end %>
 
-    <div class="actions">
-      <%= f.submit "Entrar", class: 'btn btn-primary my-2'%>
+      <div class="form-group col-md-12 pe-3 mb-2">
+        <%= f.label :password %>
+        <%= f.password_field :password, autocomplete: "current-password", class: 'form-control' %>
+      </div>
+
+      <% if devise_mapping.rememberable? %>
+        <div class="form-check form-switch d-flex justify-content-center py-2">
+          <%= f.check_box :remember_me, class: 'form-check-input' %>
+          <%= f.label :remember_me, class: 'ms-1 form-check-label' %>
+        </div>
+      <% end %>
+    </div>
+
+    <div class="actions d-flex justify-content-center">
+      <%= f.submit "Entrar", class: 'btn btn-dark rounded-pill px-4 mt-1' %>
     </div>
   <% end %>
 
-  <%= render "residents/shared/links" %>
+  <div class="d-flex justify-content-center mt-3">
+    <%= render "residents/shared/links" %>
+  </div>
 </div>

--- a/app/views/residents/shared/_links.html.erb
+++ b/app/views/residents/shared/_links.html.erb
@@ -1,5 +1,5 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to "Entrar", new_session_path(resource_name) %><br />
+  <%= link_to "Entrar", new_session_path(resource_name), class: 'btn btn-dark rounded-pill px-4'%><br />
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
@@ -7,7 +7,7 @@
 <% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Esqueceu sua senha?", new_password_path(resource_name) %><br />
+  <%= link_to "Esqueceu sua senha?", new_password_path(resource_name), class: 'btn btn-dark rounded-pill px-4' %><br />
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>

--- a/app/views/shared/_errors.html.erb
+++ b/app/views/shared/_errors.html.erb
@@ -1,8 +1,6 @@
 <% if model.errors.any? %>
-  <div class="alert alert-secondary pb-0" role="alert">
-    <h4 class="alert-heading">
-      <p>Verifique os erros abaixo</p>
-    </h4>
+  <section class="alert alert-danger pb-0" role="alert">
+    <strong>Verifique os Erros Abaixo</strong>
     <div class="my-0">
       <ul>
         <% model.errors.full_messages.each do |msg| %>
@@ -10,5 +8,5 @@
         <% end %>
       </ul>
     </div>
-  </div>
+  </section>
 <% end %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -48,19 +48,19 @@
           <ul class="navbar-nav justify-content-end flex-grow-1 pe-3">
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle text-white" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-                Gerenciar usuarios
+                Gerenciar Usuários
               </a>
 
               <ul class="dropdown-menu dropdown-menu-dark" style="background-color: #4c677f">
-                <li><%= link_to 'Cadastrar novo administrador', new_manager_path, class: "dropdown-item" %></li>
+                <li><%= link_to 'Cadastrar Administrador', new_manager_path, class: "dropdown-item" %></li>
                 <li><hr class="nav-divider m-0"></li>
-                <li><%= link_to 'Cadastrar morador', new_resident_path, class: "dropdown-item" %></li>
+                <li><%= link_to 'Cadastrar Morador', new_resident_path, class: "dropdown-item" %></li>
               </ul>
             </li>
 
             <li><hr class="nav-divider m-0"></li>
             <li class="nav-item">
-              <%= link_to 'Criar Condominio', new_condo_path, class: 'nav-link custom-element text-white', data: { turbo: false } %>
+              <%= link_to 'Criar Condomínio', new_condo_path, class: 'nav-link custom-element text-white', data: { turbo: false } %>
             </li>
 
             <li><hr class="nav-divider m-0"></li>
@@ -77,13 +77,12 @@
             <li class="nav-item">
               <a class="nav-link custom-element text-white" href="#" data-bs-toggle="modal" data-bs-target="#condoSelectPopupForCommonAreas">Criar Área Comum</a>
             </li>
-
           </ul>
         </div>
       </div>
     <% end %>
-
   </div>
+  
   <% unless controller_name == 'home' %>
     <%= render 'shared/breadcrumb' %>
   <% end %>

--- a/app/views/towers/edit_floor_units.html.erb
+++ b/app/views/towers/edit_floor_units.html.erb
@@ -1,12 +1,13 @@
-<section>
-  <%= render 'shared/errors', model: @tower %>
+<%= render 'shared/errors', model: @tower %>
+
+<section class="bg-white rounded-5 py-4 px-5 shadow">
   <h1>Atualizar Pavimento Tipo do(a) <%= @tower.name %></h1>
 
   <%= form_with url: update_floor_units_condo_tower_path(@tower.condo, @tower), method: :patch do |f| %>
     
-    <div class="form-group p-2">
+    <div class="form-group row p-2">
       <% @tower.units_per_floor.times do |index| %>
-        <div id = "<%= "unit-#{index + 1}" %>" class="mt-2">
+        <div id="<%= "unit-#{index + 1}" %>" class="col-md-6 mt-2">
           <%= f.label "unit_types[#{index}]", "Unidade modelo #{index + 1}" %>
           <%= f.collection_select "unit_types[#{index}]", @unit_types, :id, :description,
               { prompt: "Tipo de Unidade" }, { :class => "form-control form-select" } %>
@@ -14,9 +15,8 @@
       <% end %>
     </div>
 
-    <div>
-      <%= f.submit 'Atualizar Pavimento Tipo', class: "btn btn-dark" %>
+    <div class="d-flex justify-content-center">
+      <%= f.submit 'Atualizar Pavimento Tipo', class: "btn btn-dark rounded-pill px-4 mt-3" %>
     </div>
-
   <% end %>
 </section>

--- a/app/views/towers/new.html.erb
+++ b/app/views/towers/new.html.erb
@@ -1,28 +1,30 @@
-<section>
-  <%= render 'shared/errors', model: @tower %>
+<%= render 'shared/errors', model: @tower %>
+
+<section class="bg-white rounded-5 py-4 px-5 shadow">
   <h1>Cadastrar Torre</h1>
   
   <%= form_with model: [@tower.condo, @tower] do |f| %>
     <div class="form-row p-2">
-      <div class="form-group col-md-6 pe-3">
+      <div class="form-group col-md-12 pe-3">
         <%= f.label :name %>
-        <%= f.text_field :name, class:"form-control", placeholder: "Torre A" %>
+        <%= f.text_field :name, class:"form-control" %>
       </div>
     </div>
     
     <div class="form-row d-flex p-2">
-      <div class="form-group col-md-3 pe-3">
+      <div class="form-group col-md-6 pe-3">
         <%= f.label :floor_quantity %>
         <%= f.number_field :floor_quantity, class:"form-control", min: 1, step: 1 %>
       </div>
-      <div class="form-group col-md-3 pe-3">
+      
+      <div class="form-group col-md-6 pe-3">
         <%= f.label :units_per_floor %>
         <%= f.number_field :units_per_floor, class:"form-control", min: 1, step: 1 %>
       </div>
     </div>
 
-    <div class="form-group">
-      <%= f.submit class:"btn btn-dark" %>
+    <div class="d-flex justify-content-center">
+      <%= f.submit class:"btn btn-dark rounded-pill px-4 mt-3" %>
     </div>
   <% end %>
 </section>

--- a/app/views/towers/show.html.erb
+++ b/app/views/towers/show.html.erb
@@ -1,13 +1,12 @@
-<section>
+<section class="bg-white rounded-5 py-4 px-5 shadow">
   <h1><%= @tower.name %></h1>
-
-  <p>Quantidade de Andares: <%= @tower.floor_quantity %></p> 
+  <p class="mt-4">Quantidade de Andares: <%= @tower.floor_quantity %></p> 
   <p>Apartamentos por Andar: <%= @tower.units_per_floor %></p>
 
   <h2>Andares</h2>
   <% @tower.floors.each do |floor| %>
-    <p><%= link_to("#{floor.identifier}º Andar", tower_floor_path(@tower, floor)) %><p>
+    <p><%= link_to "#{floor.identifier}º Andar", tower_floor_path(@tower, floor) %><p>
   <% end %>
 
-  <%= link_to 'Editar Pavimento Tipo', edit_floor_units_condo_tower_path(@tower.condo, @tower), class:"btn btn-dark" %>
+  <%= link_to 'Editar Pavimento Tipo', edit_floor_units_condo_tower_path(@tower.condo, @tower), class: "btn btn-dark rounded-pill px-4 mt-3" %>
 </section>

--- a/app/views/unit_types/edit.html.erb
+++ b/app/views/unit_types/edit.html.erb
@@ -1,21 +1,23 @@
-<h1>Editar tipo de unidade</h1>
-
 <%= render 'shared/errors', model: @unit_type %>
 
-<%= form_with(model: @unit_type) do |f| %>
-  <div class="form-row d-flex p-2">
-    <div class="form-group col-md-4 pe-3">
-      <%= f.label :description %>
-      <%= f.text_area :description, class:"form-control" %>
+<section class="bg-white rounded-5 py-4 px-5 shadow">
+  <h1>Editar Tipo de Unidade</h1>
+
+  <%= form_with(model: @unit_type) do |f| %>
+    <div class="form-row d-flex p-2">
+      <div class="form-group col-md-6 pe-3">
+        <%= f.label :description %>
+        <%= f.text_area :description, class:"form-control" %>
+      </div>
+
+      <div class="form-group col-md-6 pe-3">
+        <%= f.label :metreage %>
+        <%= f.number_field :metreage, step: 0.01, class:"form-control" %>
+      </div>
     </div>
 
-    <div class="form-group col-md-4 pe-3">
-      <%= f.label :metreage %>
-      <%= f.number_field :metreage, step: 0.01, class:"form-control" %>
+    <div class="d-flex justify-content-center">
+      <%= f.submit class: "btn btn-dark rounded-pill px-4 mt-3" %>
     </div>
-  </div>
-
-  <div>
-    <%= f.submit class:"btn btn-dark" %>
-  </div>
-<% end %>
+  <% end %>
+</section>

--- a/app/views/unit_types/index.html.erb
+++ b/app/views/unit_types/index.html.erb
@@ -1,1 +1,0 @@
-<h1>Tipos de Unidade</h1>

--- a/app/views/unit_types/new.html.erb
+++ b/app/views/unit_types/new.html.erb
@@ -1,21 +1,23 @@
-<h1>Cadastrar um novo tipo de unidade</h1>
-
 <%= render 'shared/errors', model: @unit_type %>
 
-<%= form_with(model: [@condo, @unit_type]) do |f| %>
-  <div class="form-row d-flex p-2">
-    <div class="form-group col-md-4 pe-3">
-      <%= f.label :description %>
-      <%= f.text_area :description, class:"form-control" %>
+<section class='bg-white rounded-5 py-3 px-5 shadow'>
+  <h1>Cadastrar um novo tipo de unidade</h1>
+
+  <%= form_with(model: [@condo, @unit_type]) do |f| %>
+    <div class="form-row d-flex p-2">
+      <div class="form-group col-md-6 pe-3">
+        <%= f.label :description %>
+        <%= f.text_area :description, class: "form-control" %>
+      </div>
+
+      <div class="form-group col-md-6 pe-3">
+        <%= f.label :metreage %>
+        <%= f.number_field :metreage, step: 0.01, class: "form-control", placeholder: "50.42" %>
+      </div>
     </div>
 
-    <div class="form-group col-md-4 pe-3">
-      <%= f.label :metreage %>
-      <%= f.number_field :metreage, step: 0.01, class:"form-control" %>
+    <div class="d-flex justify-content-center">
+      <%= f.submit class: "btn btn-dark rounded-pill px-4 mt-3" %>
     </div>
-  </div>
-
-  <div>
-    <%= f.submit class:"btn btn-dark"%>
-  </div>
-<% end %>
+  <% end %>
+</section>

--- a/app/views/unit_types/show.html.erb
+++ b/app/views/unit_types/show.html.erb
@@ -1,17 +1,10 @@
-<h1>Tipo de unidade</h1>
+<section class="bg-white rounded-5 py-4 px-5 shadow">
+  <h1>Tipo de unidade</h1>
+  <p class="mt-4">Descrição: <%= @unit_type.description %></p>
+  <p>Metragem: <%= @unit_type.metreage_to_square_meters %></p>
+  <p>Fração Ideal: <%= @unit_type.fraction_to_percentage %></p>
 
-<div>
-  Descrição: <%= @unit_type.description %>
-</div>
-
-<div>
-  Metragem: <%= @unit_type.metreage_to_square_meters %>
-</div>
-
-<div>
-  Fração Ideal: <%= @unit_type.fraction_to_percentage %>
-</div>
-
-<div>
-  <%= link_to 'Editar', edit_unit_type_path(@unit_type), class:"btn btn-dark" %>
-</div>
+  <div>
+    <%= link_to 'Editar', edit_unit_type_path(@unit_type), class: "btn btn-dark rounded-pill px-4 mt-3" %>
+  </div>
+</section>

--- a/app/views/units/show.html.erb
+++ b/app/views/units/show.html.erb
@@ -1,9 +1,7 @@
-<h1><%= @tower.name %></h1>
-
-<h2><%= @unit.floor.print_identifier %></h2>
-
-<h3><%= @unit.print_identifier %></h3> 
-
-<p><%= @unit.unit_type.description %></p>
-
-<p><%= @unit.unit_type.metreage_to_square_meters %></p>
+<section class='bg-white rounded-5 py-4 px-5 shadow'>
+  <h1><%= @tower.name %></h1>
+  <h2><%= @unit.floor.print_identifier %></h2>
+  <h3><%= @unit.print_identifier %></h3> 
+  <p><%= @unit.unit_type.description %></p>
+  <p><%= @unit.unit_type.metreage_to_square_meters %></p>
+</section>

--- a/config/locales/models/resident.pt-BR.yml
+++ b/config/locales/models/resident.pt-BR.yml
@@ -19,6 +19,7 @@ pt-BR:
         email: 'E-mail'
         password: 'Senha'
         password_confirmation: 'Confirmar Senha'
+        remember_me: 'Lembre-se de mim'
         resident_type: 'Tipo de Morador'
         condo_id: 'Condomínio'
         tower_id: 'Torre'

--- a/spec/system/condos/manager_register_condo_spec.rb
+++ b/spec/system/condos/manager_register_condo_spec.rb
@@ -8,11 +8,11 @@ describe 'Manager register condo' do
     visit root_path
     within('nav') do
       click_on id: 'side-menu'
-      click_on 'Criar Condominio'
+      click_on 'Criar Condomínio'
     end
 
     expect(current_path).to eq new_condo_path
-    expect(page).to have_content('Cadastre um novo Condomínio:')
+    expect(page).to have_content('Cadastre um novo Condomínio')
   end
 
   it 'must be authenticated as manager' do
@@ -21,7 +21,7 @@ describe 'Manager register condo' do
     expect(current_path).to eq new_manager_session_path
   end
 
-  it 'sucessfully' do
+  it 'successfully' do
     manager = create(:manager)
 
     login_as(manager, scope: :manager)

--- a/spec/system/manager/manager_register_new_manager_spec.rb
+++ b/spec/system/manager/manager_register_new_manager_spec.rb
@@ -8,8 +8,8 @@ describe 'Manager registers new manager' do
     visit root_path
     within 'nav' do
       click_on id: 'side-menu'
-      click_on 'Gerenciar usuarios'
-      click_on 'Cadastrar novo administrador'
+      click_on 'Gerenciar Usuários'
+      click_on 'Cadastrar Administrador'
     end
     fill_in 'Nome Completo', with: 'Erika Campos'
     fill_in 'CPF', with: CPF.generate(format: true)
@@ -28,8 +28,8 @@ describe 'Manager registers new manager' do
     visit root_path
     within 'nav' do
       click_on id: 'side-menu'
-      click_on 'Gerenciar usuarios'
-      click_on 'Cadastrar novo administrador'
+      click_on 'Gerenciar Usuários'
+      click_on 'Cadastrar Administrador'
     end
     fill_in 'Nome Completo', with: ''
     fill_in 'CPF', with: ''

--- a/spec/system/resident/manager_register_new_resident_spec.rb
+++ b/spec/system/resident/manager_register_new_resident_spec.rb
@@ -18,8 +18,8 @@ describe 'Manager registers new resident' do
     visit root_path
     within 'nav' do
       click_on id: 'side-menu'
-      click_on 'Gerenciar usuarios'
-      click_on 'Cadastrar morador'
+      click_on 'Gerenciar Usuários'
+      click_on 'Cadastrar Morador'
     end
 
     fill_in 'Nome Completo', with: 'Adroaldo Junior'
@@ -58,10 +58,11 @@ describe 'Manager registers new resident' do
 
     login_as manager, scope: :manager
     visit root_path
+
     within 'nav' do
       click_on id: 'side-menu'
-      click_on 'Gerenciar usuarios'
-      click_on 'Cadastrar morador'
+      click_on 'Gerenciar Usuários'
+      click_on 'Cadastrar Morador'
     end
 
     fill_in 'Nome Completo', with: ''


### PR DESCRIPTION
### Introdução
A partir da _sprint review_, vimos a urgência de finalizar a estilização de partes da aplicação. Este PR traz mais atualizações de estilização para essa aplicação. A fim de trazer uma melhor experiência de usuário, inserimos conteúdos de telas de detalhes e formulários dentro de _cards_, padronizamos o estilo de todos os formulários, e fizemos alguns ajustes no estilo e posicionamento das mensagens de erro.

### Objetivos
- Inserir conteúdos de telas de detalhes e formulários dentro de **cards**
- Padronizar o estilo de todos os **formulários**
- Ajustar exibição de **mensagens de erro** nos formulários

### Detalhes
O título, campos e botões dos formulários agora aparecem dentro de um _card_ sombreado para separar melhor o conteúdo principal e os botões estão arredondados em formato de pílula para seguir o padrão da aplicação.
- ![Tela de cadastro do morador](https://github.com/user-attachments/assets/f75b3cdd-a134-4d85-a760-32c37afa22c7)
- ![Tela de cadastro de torre](https://github.com/user-attachments/assets/9a76037e-d575-4308-b80a-6001684acdc3)

O título, detalhes e botões da tela de detalhes também aparecem dentro de `cards`, seguindo o mesmo estilo dos formulários.
- ![Tela de detalhes da unidade](https://github.com/user-attachments/assets/bf32f70c-f56c-4e00-bcba-f5d494aa744a)

Todas as mensagens de erro agora aparecem fora do _card_ no topo da página, em cor vermelha, seguindo o padroniizando o estilo.
- ![Mensagens de erro fora do card](https://github.com/user-attachments/assets/05169b3a-4100-4cf3-9389-0021577c3983)

Ajustamos alguns testes de sistema para se adequarem às novas mudanças de estilo e navegação.

Resolve a issue #91 