### PR TITLE
Lista faturas index

### DIFF
--- a/app/controllers/bills_controller.rb
+++ b/app/controllers/bills_controller.rb
@@ -3,19 +3,20 @@ class BillsController < ApplicationController
   before_action :unit_for_current_resident
   rescue_from Faraday::ConnectionFailed, with: :connection_refused
   before_action :request_open_bills_list
+
   def index; end
-end
 
-private
+  private
 
-def unit_for_current_resident
-  @unit = current_resident.residence
-end
+  def unit_for_current_resident
+    @unit = current_resident.residence
+  end
 
-def request_open_bills_list
-  @bills = Bill.request_open_bills(@unit.id)
-end
+  def request_open_bills_list
+    @bills = Bill.request_open_bills(@unit.id)
+  end
 
-def connection_refused
-  redirect_to root_path, alert: t('alerts.bill.lost_connection')
+  def connection_refused
+    redirect_to root_path, alert: t('alerts.bill.lost_connection')
+  end
 end

--- a/app/controllers/bills_controller.rb
+++ b/app/controllers/bills_controller.rb
@@ -1,0 +1,21 @@
+class BillsController < ApplicationController
+  #before_action :authenticate_resident!, only: %i[index]
+  before_action :unit_for_current_resident
+  rescue_from Faraday::ConnectionFailed, with: :connection_refused
+  before_action :request_open_bills_list
+  def index; end
+end
+
+private
+
+def unit_for_current_resident
+  @unit = current_resident.residence
+end
+
+def request_open_bills_list
+  @bills = Bill.request_open_bills(@unit.id)
+end
+
+def connection_refused
+  redirect_to root_path, notice: t('alerts.bill.lost_connection')
+end

--- a/app/controllers/bills_controller.rb
+++ b/app/controllers/bills_controller.rb
@@ -1,5 +1,5 @@
 class BillsController < ApplicationController
-  #before_action :authenticate_resident!, only: %i[index]
+  before_action :authenticate_resident!, only: %i[index]
   before_action :unit_for_current_resident
   rescue_from Faraday::ConnectionFailed, with: :connection_refused
   before_action :request_open_bills_list

--- a/app/controllers/bills_controller.rb
+++ b/app/controllers/bills_controller.rb
@@ -3,6 +3,7 @@ class BillsController < ApplicationController
   before_action :unit_for_current_resident
   rescue_from Faraday::ConnectionFailed, with: :connection_refused
   before_action :request_open_bills_list
+  before_action :set_breadcrumbs_for_index, only: %i[index]
 
   def index; end
 
@@ -18,5 +19,9 @@ class BillsController < ApplicationController
 
   def connection_refused
     redirect_to root_path, alert: t('alerts.bill.lost_connection')
+  end
+
+  def set_breadcrumbs_for_index
+    add_breadcrumb I18n.t('breadcrumb.bill.index')
   end
 end

--- a/app/controllers/bills_controller.rb
+++ b/app/controllers/bills_controller.rb
@@ -17,5 +17,5 @@ def request_open_bills_list
 end
 
 def connection_refused
-  redirect_to root_path, notice: t('alerts.bill.lost_connection')
+  redirect_to root_path, alert: t('alerts.bill.lost_connection')
 end

--- a/app/views/bills/index.html.erb
+++ b/app/views/bills/index.html.erb
@@ -1,29 +1,33 @@
-<div class='bg-white rounded-5 py-4 px-5 shadow'>
-  <section>
-    <h1>Minhas Faturas</h1>
-    <table class="table table-hover">
-      <thead>
-        <tr>
-          <th scope="col">Valor</th>
-          <th scope="col">Lançamento</th>
-          <th scope="col">Vencimento</th>
-          <th scope="col"></th>
-        </tr>
-      </thead>
-      <tbody class="bills-list">
-        <% @bills.each do |bill| %>
-          <tr class="bill">          
-            <td><%= bill.total_value_formatted %></td>
-            <td><%= bill.issue_date_formatted %></td>
-            <td><%= bill.due_date_formatted %></td>
-            <td>
-              <%= link_to bill_path(bill.id), class: "ms-auto btn btn-dark d-inline-flex align-items-center rounded-pill" do %>
-                <p style="margin: 0; font-size: 14px;">Detalhes</p> <i class="bi bi-search ms-1"></i>
-              <% end %>
-            </td>
+  <div class='bg-white rounded-5 py-4 px-5 shadow'>
+    <section>
+      <h1>Minhas Faturas</h1>
+      <table class="table table-hover">
+        <thead>
+          <tr>
+            <th scope="col">Valor</th>
+            <th scope="col">Lançamento</th>
+            <th scope="col">Vencimento</th>
+            <th scope="col"></th>
           </tr>
-        <% end %>
-      </tbody>
-    </table>
-  </section>
-</div>
+        </thead>
+        <tbody class="bills-list">
+          <% if @bills.present? && @bills.any? %>
+            <% @bills.each do |bill| %>
+              <tr class="bill">          
+                <td><%= bill.total_value_formatted %></td>
+                <td><%= bill.issue_date_formatted %></td>
+                <td><%= bill.due_date_formatted %></td>
+                <td>
+                  <%= link_to bill_path(bill.id), class: "ms-auto btn btn-dark d-inline-flex align-items-center rounded-pill" do %>
+                    <p style="margin: 0; font-size: 14px;">Detalhes</p> <i class="bi bi-search ms-1"></i>
+                  <% end %>
+                </td>
+              </tr>
+            <% end %>
+          <% else %>
+            <p>Não há faturas em aberto</p>
+          <% end %>
+        </tbody>
+      </table>
+    </section>
+  </div>

--- a/app/views/bills/index.html.erb
+++ b/app/views/bills/index.html.erb
@@ -19,7 +19,7 @@
                 <td><%= bill.due_date_formatted %></td>
                 <td>
                   <%= link_to bill_path(bill.id), class: "ms-auto btn btn-dark d-inline-flex align-items-center rounded-pill" do %>
-                    <p style="margin: 0; font-size: 14px;">Detalhes</p> <i class="bi bi-search ms-1"></i>
+                    <p style="margin: 0; font-size: 14px;">Em construção</p> <i class="bi bi-search ms-1"></i>
                   <% end %>
                 </td>
               </tr>

--- a/app/views/bills/index.html.erb
+++ b/app/views/bills/index.html.erb
@@ -1,0 +1,29 @@
+<div class='bg-white rounded-5 py-4 px-5 shadow'>
+  <section>
+    <h1>Minhas Faturas</h1>
+    <table class="table table-hover">
+      <thead>
+        <tr>
+          <th scope="col">Valor</th>
+          <th scope="col">Lançamento</th>
+          <th scope="col">Vencimento</th>
+          <th scope="col"></th>
+        </tr>
+      </thead>
+      <tbody class="bills-list">
+        <% @bills.each do |bill| %>
+          <tr class="bill">          
+            <td><%= bill.total_value_formatted %></td>
+            <td><%= bill.issue_date_formatted %></td>
+            <td><%= bill.due_date_formatted %></td>
+            <td>
+              <%= link_to bill_path(bill.id), class: "ms-auto btn btn-dark d-inline-flex align-items-center rounded-pill" do %>
+                <p style="margin: 0; font-size: 14px;">Detalhes</p> <i class="bi bi-search ms-1"></i>
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </section>
+</div>

--- a/app/views/condos/dashboard/_bills.html.erb
+++ b/app/views/condos/dashboard/_bills.html.erb
@@ -25,7 +25,7 @@
         <% end %>
         <% if @bills.count > 3 %>
           <div class='d-flex'>
-            <%= link_to root_path, class:"btn py-1 rounded-pill d-flex justify-content-center align-items-center mb-2 w-25 fs-6 text-muted", style: "width: 100%;" do %>
+            <%= link_to bills_path, class:"btn py-1 rounded-pill d-flex justify-content-center align-items-center mb-2 w-25 fs-6 text-muted small", style: "width: 100%;" do %>
               <strong>ver mais</strong>
             <% end %>
           </div>

--- a/app/views/condos/dashboard/_bills.html.erb
+++ b/app/views/condos/dashboard/_bills.html.erb
@@ -17,8 +17,8 @@
               <div class="mt-3 fs-5">Valor: <%= bill.total_value_formatted %></div>
               <div class="text-muted small">Vencimento: <%= bill.due_date_formatted %></div>
             </div>
-            <%= link_to root_path, class: "ms-auto btn btn-dark d-inline-flex align-items-center rounded-pill" do %>
-              <p style="margin: 0; font-size: 14px;">Visualizar</p> <i class="bi bi-search ms-1"></i>
+            <%= link_to bill_path(bill.id), class: "ms-auto btn btn-dark d-inline-flex align-items-center rounded-pill" do %>
+              <p style="margin: 0; font-size: 14px;">Em construção</p> <i class="bi bi-search ms-1"></i>
             <% end %>
           </div>
           <hr class="m-0">

--- a/config/locales/breadcrumb.pt-BR.yml
+++ b/config/locales/breadcrumb.pt-BR.yml
@@ -30,3 +30,5 @@ pt-BR:
       new: 'Cadastrar Visitante/Funcionário'
       create: 'Cadastrar Visitante/Funcionário'
       index: 'Listagem de Visitantes/Funcionários'
+    bill:
+      index: 'Lista de faturas'

--- a/config/locales/models/bills.pt-BR.yml
+++ b/config/locales/models/bills.pt-BR.yml
@@ -1,0 +1,7 @@
+pt-BR:
+  notices:
+    bill:
+      access: 'Servidor do PagueAluguel conectado com sucesso'
+  alerts:    
+    bill:
+      lost_connection: 'Não foi possível conectar no servidor do PagueAluguel'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,8 @@ Rails.application.routes.draw do
 
   resources :unit_types, only: [:show, :edit, :update]
 
+  resources :bills, only: [:index, :show]
+
   resources :condos, only: [:new, :create, :show, :edit, :update] do
     get 'residents', on: :member
     resources :common_areas, only: [:new, :create]

--- a/spec/system/fees/user_sees_fee_index_spec.rb
+++ b/spec/system/fees/user_sees_fee_index_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+describe "user access a list of bills for it's units" do
+  it 'from the dashboard' do
+    condo = create :condo
+    resident = create(:resident, :with_residence, condo:)
+    unit11 = resident.residence
+    json_data = Rails.root.join('spec/support/json/five_bills.json').read
+    fake_response = double('faraday_response', body: json_data, success?: true)
+    allow(Faraday).to receive(:get).with("http://localhost:4000/api/v1/units/#{unit11.id}/bills").and_return(fake_response)
+
+    login_as resident, scope: :resident
+    visit condo_path condo
+    click_on 'Faturas em Aberto'
+    within '#bills' do
+      click_on 'ver mais'
+    end
+
+    expect(page).to have_content 'Minhas Faturas'
+    expect(page).to have_content '10/09/2024'
+    expect(page).to have_content 'R$ 50,00'
+    expect(page).to have_content '10/07/2024'
+    expect(page).to have_content 'R$ 10,00'
+    expect(page).to have_content '10/05/2024'
+    expect(page).to have_content 'R$ 30,00'
+    expect(page).to have_content '10/03/2024'
+    expect(page).to have_content 'R$ 25,64'
+    expect(page).to have_content '10/02/2024'
+    expect(page).to have_content 'R$ 12,34'
+  end
+end

--- a/spec/system/fees/user_sees_fee_index_spec.rb
+++ b/spec/system/fees/user_sees_fee_index_spec.rb
@@ -1,6 +1,12 @@
 require 'rails_helper'
 
 describe "user access a list of bills for it's units" do
+  it 'and are unauthenticated' do
+    visit bills_path
+
+    expect(current_path).to eq new_resident_session_path
+    expect(page).to have_content 'Para continuar, faça login ou registre-se.'
+  end
   it 'from the dashboard' do
     condo = create :condo
     resident = create(:resident, :with_residence, condo:)
@@ -27,5 +33,20 @@ describe "user access a list of bills for it's units" do
     expect(page).to have_content 'R$ 25,64'
     expect(page).to have_content '10/02/2024'
     expect(page).to have_content 'R$ 12,34'
+  end
+
+  it "and there's no data" do
+    condo = create :condo
+    resident = create(:resident, :with_residence, condo:)
+    unit11 = resident.residence
+    json_data = Rails.root.join('spec/support/json/empty_bills.json').read
+    fake_response = double('faraday_response', body: json_data, success?: true)
+    allow(Faraday).to receive(:get).with("http://localhost:4000/api/v1/units/#{unit11.id}/bills").and_return(fake_response)
+
+    login_as resident, scope: :resident
+    visit bills_path
+
+    expect(page).to have_content 'Minhas Faturas'
+    expect(page).to have_content 'Não há faturas em aberto'
   end
 end

--- a/spec/system/fees/user_sees_fee_index_spec.rb
+++ b/spec/system/fees/user_sees_fee_index_spec.rb
@@ -49,4 +49,15 @@ describe "user access a list of bills for it's units" do
     expect(page).to have_content 'Minhas Faturas'
     expect(page).to have_content 'Não há faturas em aberto'
   end
+
+  it "and there's an error due to connection lost" do
+    condo = create :condo
+    resident = create(:resident, :with_residence, condo:)
+
+    login_as resident, scope: :resident
+    visit bills_path
+
+    expect(page).to have_content 'Não foi possível conectar no servidor do PagueAluguel'
+    expect(current_path).to eq root_path
+  end
 end


### PR DESCRIPTION
### Título

Como morador, é possível ver todas as faturas em aberto em uma lista relacionadas à unidade em que reside para que possa efetuar eventual pagamento.

### Descrição

Implementada o index para as faturas vindo diretamente do PagueAluguel, mostrando a seguinte tabela.

![Captura de tela 2024-07-19 061739](https://github.com/user-attachments/assets/cae8aafb-d34b-4ebe-a53d-32ca1bf5da00)

Caso não tenham faturas em aberto, a tabela é mostrada vazia e aparece uma mensagem dizendo que não existem faturas em aberto.

Caso a conexão com o PagueAluguel seja perdida, o usuário é redirecionado para a root_path e surge o "message alert" referente.

Resolve a Issue #111 

OBS: Como pode ser visto na imagem, ficaram os botões de detalhes em progresso, pois é a task #112 