### PR TITLE
Fatura detalhes

### DIFF
--- a/app/controllers/bills_controller.rb
+++ b/app/controllers/bills_controller.rb
@@ -1,10 +1,9 @@
 class BillsController < ApplicationController
+  rescue_from Faraday::ConnectionFailed, with: :connection_refused
   before_action :authenticate_resident!, only: %i[index show]
   before_action :unit_for_current_resident
-  rescue_from Faraday::ConnectionFailed, with: :connection_refused
   before_action :request_open_bills_list, only: :index
   before_action :request_bill_details, only: :show
-  before_action :find_bill_unit, only: :show
   before_action :set_breadcrumbs_for_index, only: :index
   before_action :set_breadcrumbs_for_details, only: :show
 
@@ -24,6 +23,10 @@ class BillsController < ApplicationController
 
   def request_bill_details
     @bill = Bill.request_bill_details(params[:id])
+
+    return if @bill
+
+    redirect_to bills_path, alert: t('alerts.bill.not_found')
   end
 
   def connection_refused
@@ -36,9 +39,5 @@ class BillsController < ApplicationController
 
   def set_breadcrumbs_for_details
     add_breadcrumb I18n.t('breadcrumb.bill.show')
-  end
-
-  def find_bill_unit
-    @unit = Unit.find(@bill.unit_id)
   end
 end

--- a/app/controllers/bills_controller.rb
+++ b/app/controllers/bills_controller.rb
@@ -2,8 +2,11 @@ class BillsController < ApplicationController
   before_action :authenticate_resident!, only: %i[index show]
   before_action :unit_for_current_resident
   rescue_from Faraday::ConnectionFailed, with: :connection_refused
-  before_action :request_open_bills_list
-  before_action :set_breadcrumbs_for_index, only: %i[index]
+  before_action :request_open_bills_list, only: :index
+  before_action :request_bill_details, only: :show
+  before_action :find_bill_unit, only: :show
+  before_action :set_breadcrumbs_for_index, only: :index
+  before_action :set_breadcrumbs_for_details, only: :show
 
   def index; end
 
@@ -19,11 +22,23 @@ class BillsController < ApplicationController
     @bills = Bill.request_open_bills(@unit.id)
   end
 
+  def request_bill_details
+    @bill = Bill.request_bill_details(params[:id])
+  end
+
   def connection_refused
     redirect_to root_path, alert: t('alerts.bill.lost_connection')
   end
 
   def set_breadcrumbs_for_index
     add_breadcrumb I18n.t('breadcrumb.bill.index')
+  end
+
+  def set_breadcrumbs_for_details
+    add_breadcrumb I18n.t('breadcrumb.bill.show')
+  end
+
+  def find_bill_unit
+    @unit = Unit.find(@bill.unit_id)
   end
 end

--- a/app/controllers/bills_controller.rb
+++ b/app/controllers/bills_controller.rb
@@ -1,11 +1,13 @@
 class BillsController < ApplicationController
-  before_action :authenticate_resident!, only: %i[index]
+  before_action :authenticate_resident!, only: %i[index show]
   before_action :unit_for_current_resident
   rescue_from Faraday::ConnectionFailed, with: :connection_refused
   before_action :request_open_bills_list
   before_action :set_breadcrumbs_for_index, only: %i[index]
 
   def index; end
+
+  def show; end
 
   private
 

--- a/app/controllers/bills_controller.rb
+++ b/app/controllers/bills_controller.rb
@@ -4,8 +4,7 @@ class BillsController < ApplicationController
   before_action :unit_for_current_resident
   before_action :request_open_bills_list, only: :index
   before_action :request_bill_details, only: :show
-  before_action :set_breadcrumbs_for_index, only: :index
-  before_action :set_breadcrumbs_for_details, only: :show
+  before_action :set_breadcrumbs_for_action, only: %i[index show]
 
   def index; end
 
@@ -24,20 +23,14 @@ class BillsController < ApplicationController
   def request_bill_details
     @bill = Bill.request_bill_details(params[:id])
 
-    return if @bill
-
-    redirect_to bills_path, alert: t('alerts.bill.not_found')
+    redirect_to bills_path, alert: t('alerts.bill.not_found') unless @bill
   end
 
   def connection_refused
     redirect_to root_path, alert: t('alerts.bill.lost_connection')
   end
 
-  def set_breadcrumbs_for_index
-    add_breadcrumb I18n.t('breadcrumb.bill.index')
-  end
-
-  def set_breadcrumbs_for_details
-    add_breadcrumb I18n.t('breadcrumb.bill.show')
+  def set_breadcrumbs_for_action
+    add_breadcrumb I18n.t("breadcrumb.bill.#{action_name}")
   end
 end

--- a/app/controllers/condos_controller.rb
+++ b/app/controllers/condos_controller.rb
@@ -1,5 +1,4 @@
 class CondosController < ApplicationController
-  rescue_from Faraday::ConnectionFailed, with: :connection_refused
   before_action :authenticate_manager!, only: %i[new create edit update residents]
   before_action :set_condo, only: %i[show edit update add_manager associate_manager residents]
   before_action :set_breadcrumbs_for_details, only: %i[show edit update add_manager associate_manager]
@@ -89,11 +88,8 @@ class CondosController < ApplicationController
   def request_bills
     return unless resident_signed_in? && current_resident.residence.present?
 
-    @bills = Bill.request_open_bills(current_resident.residence.id)
-  end
-
-  def connection_refused
-    @refused = true
-    render 'show', status: :unprocessable_entity
+    result = Bill.safe_request_open_bills(current_resident.residence.id)
+    @bills = result[:bills]
+    @bills_error = result[:error]
   end
 end

--- a/app/models/bill.rb
+++ b/app/models/bill.rb
@@ -1,6 +1,6 @@
 class Bill
   attr_accessor :unit_id, :id, :condo_id, :issue_date, :due_date,
-                :total_value_cents, :status, :values, :denied, :description
+                :total_value_cents, :status, :values, :denied, :bill_details
 
   def initialize(params = {})
     @unit_id = params.fetch('unit_id', nil)
@@ -12,7 +12,7 @@ class Bill
     @status = params.fetch('status', nil)
     @values = params.fetch('values', [])
     @denied = params.fetch('denied', nil)
-    @description = params.fetch('description', [])
+    @bill_details = params.fetch('description', [])
   end
 
   def self.request_open_bills(unit_id)
@@ -27,7 +27,7 @@ class Bill
 
   def self.request_bill_details(bill_id)
     response = Faraday.get("http://localhost:4000/api/v1/bills/#{bill_id}")
-    return [] unless response.success?
+    return nil unless response.success?
 
     bill_data = JSON.parse(response.body)
     new(bill_data)

--- a/app/models/bill.rb
+++ b/app/models/bill.rb
@@ -1,5 +1,6 @@
 class Bill
-  attr_accessor :unit_id, :id, :condo_id, :issue_date, :due_date, :total_value_cents, :status, :values
+  attr_accessor :unit_id, :id, :condo_id, :issue_date, :due_date,
+                :total_value_cents, :status, :values, :denied, :description
 
   def initialize(params = {})
     @unit_id = params.fetch('unit_id', nil)
@@ -10,6 +11,8 @@ class Bill
     @total_value_cents = params.fetch('total_value_cents', nil)
     @status = params.fetch('status', nil)
     @values = params.fetch('values', [])
+    @denied = params.fetch('denied', nil)
+    @description = params.fetch('description', [])
   end
 
   def self.request_open_bills(unit_id)
@@ -20,6 +23,14 @@ class Bill
     bills_data = JSON.parse(response.body)['bills']
     bills_array = bills_data.map { |bill_data| new(bill_data) }
     bills_array.sort_by { |bill| bill.due_date.to_time.to_i }.reverse
+  end
+
+  def self.request_bill_details(bill_id)
+    response = Faraday.get("http://localhost:4000/api/v1/bills/#{bill_id}")
+    return [] unless response.success?
+
+    bill_data = JSON.parse(response.body)
+    new(bill_data)
   end
 
   def total_value_formatted

--- a/app/models/bill.rb
+++ b/app/models/bill.rb
@@ -1,6 +1,6 @@
 class Bill
-  attr_accessor :unit_id, :id, :condo_id, :issue_date, :due_date,
-                :total_value_cents, :status, :values, :denied, :bill_details
+  attr_reader :unit_id, :id, :condo_id, :issue_date, :due_date,
+              :total_value_cents, :status, :values, :denied, :bill_details
 
   def initialize(params = {})
     @unit_id = params.fetch('unit_id', nil)

--- a/app/models/bill.rb
+++ b/app/models/bill.rb
@@ -12,7 +12,7 @@ class Bill
     @status = params.fetch('status', nil)
     @values = params.fetch('values', [])
     @denied = params.fetch('denied', nil)
-    @bill_details = params.fetch('description', [])
+    @bill_details = params.fetch('bill_details', [])
   end
 
   def self.request_open_bills(unit_id)
@@ -35,6 +35,10 @@ class Bill
 
   def total_value_formatted
     "R$ #{format('%.2f', total_value_cents / 100.0).gsub('.', ',')}"
+  end
+
+  def self.format_value(value)
+    "R$ #{format('%.2f', value / 100.0).gsub('.', ',')}"
   end
 
   def due_date_formatted

--- a/app/models/bill.rb
+++ b/app/models/bill.rb
@@ -25,6 +25,10 @@ class Bill
     bills_array.sort_by { |bill| bill.due_date.to_time.to_i }.reverse
   end
 
+  def self.safe_request_open_bills(unit_id)
+    BillService.request_open_bills(unit_id)
+  end
+
   def self.request_bill_details(bill_id)
     response = Faraday.get("http://localhost:4000/api/v1/bills/#{bill_id}")
     return nil unless response.success?

--- a/app/services/bill_service.rb
+++ b/app/services/bill_service.rb
@@ -1,0 +1,15 @@
+class BillService
+  def self.request_open_bills(unit_id)
+    response = Faraday.get("http://localhost:4000/api/v1/units/#{unit_id}/bills")
+
+    return { bills: [], error: 'Conexão perdida com o servidor do PagueAlugel.' } unless response.success?
+
+    bills_data = JSON.parse(response.body)['bills']
+    bills_array = bills_data.map { |bill_data| Bill.new(bill_data) }
+    sorted_bills = bills_array.sort_by { |bill| bill.due_date.to_time.to_i }.reverse
+
+    { bills: sorted_bills, error: nil }
+  rescue Faraday::ConnectionFailed
+    { bills: [], error: 'Conexão perdida com o servidor do PagueAlugel.' }
+  end
+end

--- a/app/services/bill_service.rb
+++ b/app/services/bill_service.rb
@@ -2,7 +2,7 @@ class BillService
   def self.request_open_bills(unit_id)
     response = Faraday.get("http://localhost:4000/api/v1/units/#{unit_id}/bills")
 
-    return { bills: [], error: 'Conexão perdida com o servidor do PagueAlugel.' } unless response.success?
+    return { bills: [], error: I18n.t('alerts.bill.lost_connection') } unless response.success?
 
     bills_data = JSON.parse(response.body)['bills']
     bills_array = bills_data.map { |bill_data| Bill.new(bill_data) }
@@ -10,6 +10,6 @@ class BillService
 
     { bills: sorted_bills, error: nil }
   rescue Faraday::ConnectionFailed
-    { bills: [], error: 'Conexão perdida com o servidor do PagueAlugel.' }
+    { bills: [], error: I18n.t('alerts.bill.lost_connection') }
   end
 end

--- a/app/views/bills/index.html.erb
+++ b/app/views/bills/index.html.erb
@@ -19,7 +19,7 @@
                 <td><%= bill.due_date_formatted %></td>
                 <td>
                   <%= link_to bill_path(bill.id), class: "ms-auto btn btn-dark d-inline-flex align-items-center rounded-pill" do %>
-                    <p style="margin: 0; font-size: 14px;">Em construção</p> <i class="bi bi-search ms-1"></i>
+                    <p style="margin: 0; font-size: 14px;">Detalhes</p> <i class="bi bi-search ms-1"></i>
                   <% end %>
                 </td>
               </tr>

--- a/app/views/bills/show.html.erb
+++ b/app/views/bills/show.html.erb
@@ -1,0 +1,48 @@
+<section class="bg-white rounded-5 py-4 px-5 shadow">
+  <h1 class="mb-3">Minha Fatura</h1>
+
+  <div class="mt-4 text-muted small">
+    <p><strong>Unidade:</strong> <%= @unit.short_identifier %></p>
+    <p><strong>Condomínio:</strong> <%= @unit.condo.name %></p>
+  </div>
+
+  <div class="d-flex justify-content-center">
+      <div class="card mt-4 border border-primary shadow-lg w-25">
+        <div class="card-body d-flex flex-column align-items-center">
+          <p class="fs-3"><strong>Valor:</strong> <%= @bill.total_value_formatted %></p>
+          <strong>Vencimento:</strong> <%= @bill.due_date_formatted %>
+          <strong>Lançamento:</strong> <%= @bill.issue_date_formatted %>
+          <div>
+            <% if @bill.status == 'pending' && @bill.denied %>
+              <span class="badge rounded-pill text-bg-danger">Negada</span>
+            <% elsif @bill.status == 'pending' %>
+              <span class="badge rounded-pill text-bg-warning">Não paga</span>
+            <% elsif @bill.status == 'awaiting' %>
+              <span class="badge rounded-pill text-bg-info">Em análise</span>
+            <% elsif @bill.status == 'paid' %>
+              <span class="badge rounded-pill text-bg-success">Paga</span>
+            <% end %>
+          </div>
+        </div>
+      </div>
+  </div>
+
+  <h2 class="mb-3">Detalhamento</h2>
+
+  <table class="table table-sm">
+    <thead>
+      <tr>
+        <th scope="col">Descrição</th>
+        <th scope="col">Valor</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @bill.description do |bill| %>
+        <tr id="visitor-<%= visitor.id %>">
+          <td><%= bill.description %></td>
+          <td><%= bill.value %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</section>

--- a/app/views/bills/show.html.erb
+++ b/app/views/bills/show.html.erb
@@ -37,10 +37,10 @@
       </tr>
     </thead>
     <tbody>
-      <% @bill.description do |bill| %>
+      <% @bill.bill_details do |detail| %>
         <tr id="visitor-<%= visitor.id %>">
-          <td><%= bill.description %></td>
-          <td><%= bill.value %></td>
+          <td><%= detail.description %></td>
+          <td><%= detail.value %></td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/bills/show.html.erb
+++ b/app/views/bills/show.html.erb
@@ -37,12 +37,16 @@
       </tr>
     </thead>
     <tbody>
-      <% @bill.bill_details do |detail| %>
-        <tr id="visitor-<%= visitor.id %>">
-          <td><%= detail.description %></td>
-          <td><%= detail.value %></td>
+      <% @bill.bill_details.each do |detail| %>
+        <tr>
+          <td><%= detail['description'] %></td>
+          <td><%= Bill.format_value detail['value_cents'] %></td>
         </tr>
       <% end %>
+      <tr>
+        <td><strong>Total</strong></td>
+        <td><strong><%= @bill.total_value_formatted %></strong></td>
+      </tr>
     </tbody>
   </table>
 </section>

--- a/app/views/bills/show.html.erb
+++ b/app/views/bills/show.html.erb
@@ -13,13 +13,16 @@
           <strong>Vencimento:</strong> <%= @bill.due_date_formatted %>
           <strong>Lançamento:</strong> <%= @bill.issue_date_formatted %>
           <div>
-            <% if @bill.status == 'pending' && @bill.denied %>
-              <span class="badge rounded-pill text-bg-danger">Negada</span>
-            <% elsif @bill.status == 'pending' %>
-              <span class="badge rounded-pill text-bg-warning">Não paga</span>
-            <% elsif @bill.status == 'awaiting' %>
+            <% case @bill.status %>
+            <% when 'pending' %>
+              <% if @bill.denied %>
+                <span class="badge rounded-pill text-bg-danger">Negada</span>
+              <% else %>
+                <span class="badge rounded-pill text-bg-warning">Não paga</span>
+              <% end %>
+            <% when 'awaiting' %>
               <span class="badge rounded-pill text-bg-info">Em análise</span>
-            <% elsif @bill.status == 'paid' %>
+            <% when 'paid' %>
               <span class="badge rounded-pill text-bg-success">Paga</span>
             <% end %>
           </div>

--- a/app/views/condos/dashboard/_bills.html.erb
+++ b/app/views/condos/dashboard/_bills.html.erb
@@ -9,7 +9,7 @@
     <div class="accordion-body accordion-bills">
       <% if @bills_error.present? %>
         <div class="alert alert-warning text-center"><%= @bills_error %></div>
-      <% elsif @bills.present? && @bills.any? %>
+      <% elsif @bills&.any? %>
         <% @bills.take(3).each do |bill| %>
           <div class="d-flex align-items-center my-1 accordion-bill">
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-currency-dollar mx-2" viewBox="0 0 16 16">

--- a/app/views/condos/dashboard/_bills.html.erb
+++ b/app/views/condos/dashboard/_bills.html.erb
@@ -6,10 +6,10 @@
   </h2>
   
   <div id="bills" class="accordion-collapse collapse" data-bs-parent="#accordionExample">
-    <div class="accordion-body">
+    <div class="accordion-body accordion-bills">
       <% if !@refused && @bills.present? && @bills.any? %>
         <% @bills.take(3).each do |bill| %>
-          <div class="d-flex align-items-center my-1">
+          <div class="d-flex align-items-center my-1 accordion-bill">
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-currency-dollar mx-2" viewBox="0 0 16 16">
               <path d="M4 10.781c.148 1.667 1.513 2.85 3.591 3.003V15h1.043v-1.216c2.27-.179 3.678-1.438 3.678-3.3 0-1.59-.947-2.51-2.956-3.028l-.722-.187V3.467c1.122.11 1.879.714 2.07 1.616h1.47c-.166-1.6-1.54-2.748-3.54-2.875V1H7.591v1.233c-1.939.23-3.27 1.472-3.27 3.156 0 1.454.966 2.483 2.661 2.917l.61.162v4.031c-1.149-.17-1.94-.8-2.131-1.718zm3.391-3.836c-1.043-.263-1.6-.825-1.6-1.616 0-.944.704-1.641 1.8-1.828v3.495l-.2-.05zm1.591 1.872c1.287.323 1.852.859 1.852 1.769 0 1.097-.826 1.828-2.2 1.939V8.73z"/>
             </svg>
@@ -18,7 +18,7 @@
               <div class="text-muted small">Vencimento: <%= bill.due_date_formatted %></div>
             </div>
             <%= link_to bill_path(bill.id), class: "ms-auto btn btn-dark d-inline-flex align-items-center rounded-pill" do %>
-              <p style="margin: 0; font-size: 14px;">Em construção</p> <i class="bi bi-search ms-1"></i>
+              <p style="margin: 0; font-size: 14px;">Detalhes</p> <i class="bi bi-search ms-1"></i>
             <% end %>
           </div>
           <hr class="m-0">

--- a/app/views/condos/dashboard/_bills.html.erb
+++ b/app/views/condos/dashboard/_bills.html.erb
@@ -7,7 +7,9 @@
   
   <div id="bills" class="accordion-collapse collapse" data-bs-parent="#accordionExample">
     <div class="accordion-body accordion-bills">
-      <% if !@refused && @bills.present? && @bills.any? %>
+      <% if @bills_error.present? %>
+        <div class="alert alert-warning text-center"><%= @bills_error %></div>
+      <% elsif @bills.present? && @bills.any? %>
         <% @bills.take(3).each do |bill| %>
           <div class="d-flex align-items-center my-1 accordion-bill">
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-currency-dollar mx-2" viewBox="0 0 16 16">
@@ -30,8 +32,6 @@
             <% end %>
           </div>
         <% end %>
-      <% elsif @refused %>
-        <div class="alert alert-warning text-center">Conexão perdida com o servidor do PagueAlugel.</div>
       <% else %>
         <div class="alert alert-warning text-center">Não existem faturas em aberto.</div>
       <% end %>

--- a/config/locales/breadcrumb.pt-BR.yml
+++ b/config/locales/breadcrumb.pt-BR.yml
@@ -32,3 +32,4 @@ pt-BR:
       index: 'Listagem de Visitantes/Funcionários'
     bill:
       index: 'Lista de faturas'
+      show: 'Detalhes de fatura'

--- a/config/locales/models/bills.pt-BR.yml
+++ b/config/locales/models/bills.pt-BR.yml
@@ -1,5 +1,5 @@
 pt-BR:
   alerts:    
     bill:
-      lost_connection: 'Não foi possível conectar no servidor do PagueAluguel'
+      lost_connection: 'Conexão perdida com o servidor do PagueAlugel.'
       not_found: 'Fatura não encontrada'

--- a/config/locales/models/bills.pt-BR.yml
+++ b/config/locales/models/bills.pt-BR.yml
@@ -1,7 +1,4 @@
 pt-BR:
-  notices:
-    bill:
-      access: 'Servidor do PagueAluguel conectado com sucesso'
   alerts:    
     bill:
       lost_connection: 'Não foi possível conectar no servidor do PagueAluguel'

--- a/config/locales/models/bills.pt-BR.yml
+++ b/config/locales/models/bills.pt-BR.yml
@@ -5,3 +5,4 @@ pt-BR:
   alerts:    
     bill:
       lost_connection: 'Não foi possível conectar no servidor do PagueAluguel'
+      not_found: 'Fatura não encontrada'

--- a/spec/support/json/bill_1_details.json
+++ b/spec/support/json/bill_1_details.json
@@ -1,6 +1,6 @@
 {
-  "unit_id": 97,
-  "condo_id": 2,
+  "unit_id": 1,
+  "condo_id": 1,
   "issue_date": "2024-07-01",
   "due_date": "2024-07-29",
   "total_value_cents": 225500,

--- a/spec/support/json/bill_1_details.json
+++ b/spec/support/json/bill_1_details.json
@@ -1,0 +1,12 @@
+{
+  "unit_id": 1,
+  "condo_id": 2,
+  "issue_date": "2024-07-01",
+  "due_date": "2024-07-28",
+  "total_value_cents": 1000,
+  "status": "pending",
+  "values": {
+    "base_fee_value_cents": 250,
+    "shared_fee_value_cents": 750
+  }
+}

--- a/spec/support/json/bill_1_details.json
+++ b/spec/support/json/bill_1_details.json
@@ -1,13 +1,46 @@
 {
-  "unit_id": 1,
+  "unit_id": 97,
   "condo_id": 2,
   "issue_date": "2024-07-01",
-  "due_date": "2024-07-28",
-  "total_value_cents": 1000,
+  "due_date": "2024-07-29",
+  "total_value_cents": 225500,
   "status": "pending",
   "values": {
-    "base_fee_value_cents": 250,
-    "shared_fee_value_cents": 750
+    "base_fee_value_cents": 21100,
+    "shared_fee_value_cents": 40000,
+    "single_charge_value_cents": 44400,
+    "rent_fee_cents": 120000
   },
-  "denied": true
+  "bill_details": [
+    {
+      "value_cents": 30000,
+      "description": "Conta de Água",
+      "fee_type": "shared_fee"
+    },
+    {
+      "value_cents": 10000,
+      "description": "Conta de Luz",
+      "fee_type": "shared_fee"
+    },
+    {
+      "value_cents": 10000,
+      "description": "Taxa de Condomínio",
+      "fee_type": "base_fee"
+    },
+    {
+      "value_cents": 11100,
+      "description": "Taxa de Manutenção",
+      "fee_type": "base_fee"
+    },
+    {
+      "value_cents": 11100,
+      "description": "Multa por barulho",
+      "fee_type": "fine"
+    },
+    {
+      "value_cents": 33300,
+      "description": "Acordo entre proprietário e morador",
+      "fee_type": "other"
+    }
+  ]
 }

--- a/spec/support/json/bill_1_details.json
+++ b/spec/support/json/bill_1_details.json
@@ -8,5 +8,6 @@
   "values": {
     "base_fee_value_cents": 250,
     "shared_fee_value_cents": 750
-  }
+  },
+  "denied": true
 }

--- a/spec/system/fees/user_sees_fee_details_spec.rb
+++ b/spec/system/fees/user_sees_fee_details_spec.rb
@@ -30,6 +30,20 @@ describe 'user access the show bill page' do
     end
 
     expect(page).to have_content 'Minha Fatura'
+    expect(page).to have_content 'Conta de Água'
+    expect(page).to have_content 'R$ 300,00'
+    expect(page).to have_content 'Conta de Luz'
+    expect(page).to have_content 'R$ 100,00'
+    expect(page).to have_content 'Taxa de Condomínio'
+    expect(page).to have_content 'R$ 100,00'
+    expect(page).to have_content 'Taxa de Manutenção'
+    expect(page).to have_content 'R$ 111,00'
+    expect(page).to have_content 'Multa por barulho'
+    expect(page).to have_content 'R$ 111,00'
+    expect(page).to have_content 'Acordo entre proprietário e morador'
+    expect(page).to have_content 'R$ 333,00'
+    expect(page).to have_content 'Total'
+    expect(page).to have_content 'R$ 2255,00'
   end
 
   it "and there's no data for bill" do

--- a/spec/system/fees/user_sees_fee_details_spec.rb
+++ b/spec/system/fees/user_sees_fee_details_spec.rb
@@ -56,7 +56,7 @@ describe 'user access the show bill page' do
 
     first_bill_id_from_five_json = 11
     json_data_details = Rails.root.join('spec/support/json/empty_bills.json').read
-    fake_response_details = double('faraday_response', body: json_data_details, success?: false, status: 404)
+    fake_response_details = double('faraday_response', body: json_data_details, success?: false, status: :not_found)
     allow(Faraday).to receive(:get).with("http://localhost:4000/api/v1/bills/#{first_bill_id_from_five_json}").and_return(fake_response_details)
 
     login_as resident, scope: :resident
@@ -74,7 +74,7 @@ describe 'user access the show bill page' do
     login_as resident, scope: :resident
     visit bills_path
 
-    expect(page).to have_content 'Não foi possível conectar no servidor do PagueAluguel'
+    expect(page).to have_content 'Conexão perdida com o servidor do PagueAlugel.'
     expect(current_path).to eq root_path
   end
 end

--- a/spec/system/fees/user_sees_fee_details_spec.rb
+++ b/spec/system/fees/user_sees_fee_details_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe 'user access the show bill page' do
+  it 'and are unauthenticated' do
+    external_server_bill_id = 1
+    visit bill_path external_server_bill_id
+
+    expect(current_path).to eq new_resident_session_path
+    expect(page).to have_content 'Para continuar, faça login ou registre-se.'
+  end
+
+  it 'and sees all details' do
+
+  end
+
+  it "and there's no data for bill" do
+
+  end
+
+  it "and there's an external error" do
+
+  end
+end

--- a/spec/system/fees/user_sees_fee_index_spec.rb
+++ b/spec/system/fees/user_sees_fee_index_spec.rb
@@ -53,6 +53,7 @@ describe "user access a list of bills for it's units" do
   it "and there's an error due to connection lost" do
     condo = create :condo
     resident = create(:resident, :with_residence, condo:)
+    allow(Faraday).to receive(:get).and_raise(Faraday::ConnectionFailed)
 
     login_as resident, scope: :resident
     visit bills_path

--- a/spec/system/fees/user_sees_fee_index_spec.rb
+++ b/spec/system/fees/user_sees_fee_index_spec.rb
@@ -59,7 +59,7 @@ describe "user access a list of bills for it's units" do
     login_as resident, scope: :resident
     visit bills_path
 
-    expect(page).to have_content 'Não foi possível conectar no servidor do PagueAluguel'
+    expect(page).to have_content 'Conexão perdida com o servidor do PagueAlugel.'
     expect(current_path).to eq root_path
   end
 end

--- a/spec/system/fees/user_sees_fee_index_spec.rb
+++ b/spec/system/fees/user_sees_fee_index_spec.rb
@@ -7,6 +7,7 @@ describe "user access a list of bills for it's units" do
     expect(current_path).to eq new_resident_session_path
     expect(page).to have_content 'Para continuar, faça login ou registre-se.'
   end
+
   it 'from the dashboard' do
     condo = create :condo
     resident = create(:resident, :with_residence, condo:)

--- a/spec/system/fees/user_sees_fee_spec.rb
+++ b/spec/system/fees/user_sees_fee_spec.rb
@@ -69,6 +69,7 @@ describe 'user access condo show' do
   it 'and connection is lost with the external API' do
     condo = create :condo
     resident = create(:resident, :with_residence, condo:)
+    allow(Faraday).to receive(:get).and_raise(Faraday::ConnectionFailed)
 
     login_as resident, scope: :resident
 


### PR DESCRIPTION
### Título

Como morador, é possível ver a tela de detalhes de uma fatura para ser possível analisar cada valor que compõem o total da fatura


### Descrição


Esse é o terceiro de quatro PRs que implementam o pagamento de faturas. Nesse as funcionalidades estão mais coerentes e todos os botões da interface estão funcionais

Caso não seja possível ver os detalhes de uma unidade, por questão de erro externo do servidor, ou por não determinada fatura no bando do PagueAluguel, o usuário é redirecionado para a tela de index com o devido alert.

No caso de sucesso essa é a tela que aparece

![Captura de tela 2024-07-19 202727](https://github.com/user-attachments/assets/534bdde9-641f-4897-93a4-0e803356beb2)


Resolve a Issue #112 