### PR TITLE
Estilização para exibição de erros em formulários

### DIFF
--- a/app/views/common_areas/edit.html.erb
+++ b/app/views/common_areas/edit.html.erb
@@ -1,4 +1,3 @@
-<%= render 'shared/errors', model: @common_area %>
 <div class='bg-white rounded-5 py-4 px-5 shadow'>
   <h1>Editar área comum</h1>
 
@@ -6,17 +5,20 @@
     <div class="form-row row p-2">
       <div class="form-group col-md-6 pe-3 mb-2">
         <%= f.label :name %>
-        <%= f.text_field :name, class: 'form-control' %>
+        <%= f.text_field :name, class: "form-control #{'is-invalid' if @common_area.errors[:name].any?}" %>
+        <%= render("shared/errors", model: @common_area, attribute: :name) if @common_area.errors[:name].any? %>
       </div>
 
       <div class="form-group col-md-6 pe-3 mb-2">
         <%= f.label :max_occupancy%>
-        <%= f.number_field :max_occupancy, class: 'form-control' %>
+        <%= f.number_field :max_occupancy, class: "form-control #{'is-invalid' if @common_area.errors[:max_occupancy].any?}" %>
+        <%= render("shared/errors", model: @common_area, attribute: :max_occupancy) if @common_area.errors[:max_occupancy].any? %>
       </div>
 
       <div class="form-group col-md-6 pe-3 mb-2">
         <%= f.label :description %>
-        <%= f.text_area :description, class: 'form-control' %>
+        <%= f.text_area :description, class: "form-control #{'is-invalid' if @common_area.errors[:description].any?}" %>
+        <%= render("shared/errors", model: @common_area, attribute: :description) if @common_area.errors[:description].any? %>
       </div>
 
       <div class="form-group col-md-6 pe-3 mb-2">

--- a/app/views/common_areas/new.html.erb
+++ b/app/views/common_areas/new.html.erb
@@ -1,5 +1,3 @@
-<%= render 'shared/errors', model: @common_area %>
-
 <div class='bg-white rounded-5 py-3 px-5 shadow'>
   <h1>Cadastrar nova área comum</h1>
 
@@ -7,17 +5,20 @@
     <div class="form-row row p-2">
       <div class="form-group col-md-6 pe-3 mb-2">
         <%= f.label :name %>
-        <%= f.text_field :name, class: 'form-control' %>
+        <%= f.text_field :name, class: "form-control #{'is-invalid' if @common_area.errors[:name].any?}" %>
+        <%= render("shared/errors", model: @common_area, attribute: :name) if @common_area.errors[:name].any? %>
       </div>
 
       <div class="form-group col-md-6 pe-3 mb-2">
         <%= f.label :max_occupancy%>
-        <%= f.number_field :max_occupancy, class: 'form-control' %>
+        <%= f.number_field :max_occupancy, class: "form-control #{'is-invalid' if @common_area.errors[:max_occupancy].any?}" %>
+        <%= render("shared/errors", model: @common_area, attribute: :max_occupancy) if @common_area.errors[:max_occupancy].any? %>
       </div>
 
       <div class="form-group col-md-6 pe-3 mb-2">
         <%= f.label :description %>
-        <%= f.text_area :description, class: 'form-control' %>
+        <%= f.text_area :description, class: "form-control #{'is-invalid' if @common_area.errors[:description].any?}" %>
+        <%= render("shared/errors", model: @common_area, attribute: :description) if @common_area.errors[:description].any? %>
       </div>
 
       <div class="form-group col-md-6 pe-3 mb-2">

--- a/app/views/condos/_form.html.erb
+++ b/app/views/condos/_form.html.erb
@@ -2,13 +2,15 @@
   <div class="form-row d-flex p-2">
     <div class="form-group col-md-6 pe-3">
       <%= f.label :name %>
-      <%= f.text_field :name, class:"form-control" %>
+      <%= f.text_field :name, class:"form-control #{'is-invalid' if @condo.errors[:name].any?}" %>
+      <%= render("shared/errors", model: @condo, attribute: :name) if @condo.errors[:name].any? %>
     </div>
     
     <div class="form-group col-md-6" data-controller="mask">
       <%= f.label :registration_number %>
-      <%= f.text_field :registration_number, class:"form-control", placeholder: "00.111.222/3333-44" ,
-          maxlength: "18", :'data-action' => 'keyup->mask#RegistrationNumberPressed' %>
+      <%= f.text_field :registration_number, class:"form-control #{'is-invalid' if @condo.errors[:registration_number].any?}", 
+          placeholder: "00.111.222/3333-44", maxlength: "18", :'data-action' => 'keyup->mask#RegistrationNumberPressed' %>
+      <%= render("shared/errors", model: @condo, attribute: :registration_number) if @condo.errors[:registration_number].any? %>
     </div>
   </div>
 
@@ -17,24 +19,28 @@
       <div class="form-row d-flex p-2">
         <div class="form-group col-md-6 pe-3">
           <%= address_f.label :public_place %>
-          <%= address_f.text_field :public_place, class:"form-control" %>
+          <%= address_f.text_field :public_place, class:"form-control #{'is-invalid' if address_f.object.errors[:public_place].any?}" %>
+          <%= render("shared/errors", model: address_f.object, attribute: :public_place) if address_f.object.errors[:public_place].any? %>
         </div>
 
         <div class="form-group col-md-2 pe-3">
           <%= address_f.label :number %>
-          <%= address_f.text_field :number, class:"form-control" %>
+          <%= address_f.text_field :number, class:"form-control #{'is-invalid' if address_f.object.errors[:number].any?}" %>
+          <%= render("shared/errors", model: address_f.object, attribute: :number) if address_f.object.errors[:number].any? %>
         </div>
 
         <div class="form-group col-md-4 pe-3">
           <%= address_f.label :neighborhood %>
-          <%= address_f.text_field :neighborhood, class:"form-control" %>
+          <%= address_f.text_field :neighborhood, class:"form-control #{'is-invalid' if address_f.object.errors[:neighborhood].any?}" %>
+          <%= render("shared/errors", model: address_f.object, attribute: :neighborhood) if address_f.object.errors[:neighborhood].any? %>
         </div>
       </div>
 
       <div class="form-row d-flex p-2">
         <div class="form-group col-md-6 pe-3">
           <%= address_f.label :city %>
-          <%= address_f.text_field :city, class:"form-control"  %>
+          <%= address_f.text_field :city, class:"form-control #{'is-invalid' if address_f.object.errors[:city].any?}" %>
+          <%= render("shared/errors", model: address_f.object, attribute: :city) if address_f.object.errors[:city].any? %>
         </div>
 
         <div class="form-group col-md-2 pe-3">
@@ -45,8 +51,9 @@
 
         <div class="form-group col-md-4 pe-3" data-controller="mask">
           <%= address_f.label :zip %>
-          <%= address_f.text_field :zip, class:"form-control", placeholder: "12345-678" ,
+          <%= address_f.text_field :zip, class:"form-control #{'is-invalid' if address_f.object.errors[:zip].any?}", placeholder: "12345-678",
           maxlength: "9", :'data-action' => 'keyup->mask#zipPressed' %>
+          <%= render("shared/errors", model: address_f.object, attribute: :zip) if address_f.object.errors[:zip].any? %>
         </div>
       </div>
     <% end %>

--- a/app/views/condos/edit.html.erb
+++ b/app/views/condos/edit.html.erb
@@ -1,4 +1,3 @@
-<%= render "shared/errors", model: @condo %>
 <section class="bg-white rounded-5 py-4 px-5 shadow">
   <h1>Editar Condomínio</h1>
   <%= render 'form' %>

--- a/app/views/condos/new.html.erb
+++ b/app/views/condos/new.html.erb
@@ -1,4 +1,3 @@
-<%= render "shared/errors", model: @condo %>
 <section class="bg-white rounded-5 py-4 px-5 shadow">
   <h1>Cadastre um novo Condomínio</h1>
   <%= render 'form' %>

--- a/app/views/managers/new.html.erb
+++ b/app/views/managers/new.html.erb
@@ -1,8 +1,6 @@
 <div class='bg-white rounded-5 py-4 px-5 shadow'>
   <h1>Cadastrar Administrador</h1>
 
-  <%= render 'shared/errors', model: @manager %>
-
   <%= form_with(model: @manager, class: 'text-center') do |f| %>
     <div class="form-row row p-2">
       <div class="form-group col-md-6 pe-3 mb-2 text-start">
@@ -11,19 +9,24 @@
       </div>
       <div class="form-group col-md-6 pe-3 mb-2 text-start">
         <%= f.label :full_name %>
-        <%= f.text_field :full_name, class: 'form-control' %>
+        <%= f.text_field :full_name, class: "form-control #{'is-invalid' if @manager.errors[:full_name].any?}" %>
+        <%= render("shared/errors", model: @manager, attribute: :full_name) if @manager.errors[:full_name].any? %>
       </div>
       <div class="form-group col-md-6 pe-3 mb-2 text-start" data-controller="mask">
         <%= f.label :registration_number %>
-        <%= f.text_field :registration_number, class: 'form-control', maxlength: "14", :'data-action' => 'keyup -> mask#registrationNumberFormated' %>
+        <%= f.text_field :registration_number, class: "form-control #{'is-invalid' if @manager.errors[:registration_number].any?}", 
+          maxlength: "14", :'data-action' => 'keyup -> mask#registrationNumberFormated' %>
+        <%= render("shared/errors", model: @manager, attribute: :registration_number) if @manager.errors[:registration_number].any? %>
       </div>
       <div class="form-group col-md-6 pe-3 mb-2 text-start">
         <%= f.label :email %>
-        <%= f.email_field :email, class: 'form-control' %>
+        <%= f.email_field :email, class: "form-control #{'is-invalid' if @manager.errors[:email].any?}" %>
+        <%= render("shared/errors", model: @manager, attribute: :email) if @manager.errors[:email].any? %>
       </div>
       <div class="form-group col-md-6 pe-3 mb-2 text-start">
         <%= f.label :password %>
-        <%= f.password_field :password, class: 'form-control' %>
+        <%= f.password_field :password, class: "form-control #{'is-invalid' if @manager.errors[:password].any?}" %>
+        <%= render("shared/errors", model: @manager, attribute: :password) if @manager.errors[:password].any? %>
       </div>
       <div class="form-group col-md-6 pe-3 mb-2 text-start">
         <%= f.label :is_super %>

--- a/app/views/owners/new.html.erb
+++ b/app/views/owners/new.html.erb
@@ -1,5 +1,3 @@
-<%= render 'shared/errors', model: @resident %>
-
 <div class="bg-white rounded-5 py-4 px-5 shadow">
   <div class="text-center">
     <h1 class="fs-2"><%= @resident.full_name %></h1>

--- a/app/views/reservations/new.html.erb
+++ b/app/views/reservations/new.html.erb
@@ -1,5 +1,3 @@
-<%= render 'shared/errors', model: @reservation %>
-
 <div class='bg-white rounded-5 py-3 px-5 shadow'>
   <h1>Escolha a data da sua reserva</h1>
  
@@ -7,7 +5,8 @@
       <div class="form-row row p-2">
         <div class="form-group col-md-12 pe-3 mb-2">
           <%= f.label :date %>
-          <%= f.date_field :date, min: Date.current, class: 'form-control' %>
+          <%= f.date_field :date, min: Date.current, class: "form-control #{'is-invalid' if @reservation.errors[:date].any?}" %>
+          <%= render("shared/errors", model: @reservation, attribute: :date) if @reservation.errors[:date].any? %>
         </div>
       </div>
       

--- a/app/views/residents/confirm.html.erb
+++ b/app/views/residents/confirm.html.erb
@@ -1,5 +1,3 @@
-<%= render 'shared/errors', model: @resident %>
-
 <div class="bg-white rounded-5 py-4 px-5 shadow">
   <h1 class="mb-5">Confirme o seu cadastro</h1>
 

--- a/app/views/residents/new.html.erb
+++ b/app/views/residents/new.html.erb
@@ -1,26 +1,27 @@
-<%= render 'shared/errors', model: @resident %>
-
 <div class="bg-white rounded-5 py-4 px-5 shadow">
   <h1>Cadastrar Morador</h1>
-
   
     <%= form_with(model: @resident) do |f| %>
       <div class="form-row d-flex p-2">
         <div class="form-group col-md-12 pe-3">
           <%= f.label :full_name %>
-          <%= f.text_field :full_name, class: 'form-control' %>
+          <%= f.text_field :full_name, class: "form-control #{'is-invalid' if @resident.errors[:full_name].any?}" %>
+          <%= render("shared/errors", model: @resident, attribute: :full_name) if @resident.errors[:full_name].any? %>
         </div>
       </div>
 
       <div class="form-row d-flex p-2">
         <div class="form-group col-md-6 pe-3", data-controller="mask">
           <%= f.label :registration_number %>
-          <%= f.text_field :registration_number, class: 'form-control', maxlength: '14', :'data-action' => 'keyup -> mask#registrationNumberFormated' %>
+          <%= f.text_field :registration_number, class: "form-control #{'is-invalid' if @resident.errors[:registration_number].any?}", 
+            maxlength: '14', :'data-action' => 'keyup -> mask#registrationNumberFormated' %>
+          <%= render("shared/errors", model: @resident, attribute: :registration_number) if @resident.errors[:registration_number].any? %>
         </div>
 
         <div class="form-group col-md-6 pe-3">
           <%= f.label :email %>
-          <%= f.email_field :email, class: 'form-control' %>
+          <%= f.email_field :email, class: "form-control #{'is-invalid' if @resident.errors[:email].any?}" %>
+          <%= render("shared/errors", model: @resident, attribute: :email) if @resident.errors[:email].any? %>
         </div>
       </div>
 

--- a/app/views/shared/_errors.html.erb
+++ b/app/views/shared/_errors.html.erb
@@ -1,12 +1,3 @@
-<% if model.errors.any? %>
-  <section class="alert alert-danger pb-0" role="alert">
-    <strong>Verifique os Erros Abaixo</strong>
-    <div class="my-0">
-      <ul>
-        <% model.errors.full_messages.each do |msg| %>
-          <li><%= msg %></li>
-        <% end %>
-      </ul>
-    </div>
-  </section>
+<% model.errors.full_messages_for(attribute).each do |message| %>
+  <div class="invalid-feedback"><%= message %></div>
 <% end %>

--- a/app/views/tenants/new.html.erb
+++ b/app/views/tenants/new.html.erb
@@ -1,5 +1,3 @@
-<%= render 'shared/errors', model: @resident %>
-
 <div class="bg-white rounded-5 py-4 px-5 shadow">
   <div class="text-center">
     <h1 class="mb-3"><%= @resident.full_name %></h1>

--- a/app/views/towers/edit_floor_units.html.erb
+++ b/app/views/towers/edit_floor_units.html.erb
@@ -1,5 +1,3 @@
-<%= render 'shared/errors', model: @tower %>
-
 <section class="bg-white rounded-5 py-4 px-5 shadow">
   <h1>Atualizar Pavimento Tipo do(a) <%= @tower.name %></h1>
 

--- a/app/views/towers/new.html.erb
+++ b/app/views/towers/new.html.erb
@@ -1,5 +1,3 @@
-<%= render 'shared/errors', model: @tower %>
-
 <section class="bg-white rounded-5 py-4 px-5 shadow">
   <h1>Cadastrar Torre</h1>
   
@@ -7,19 +5,22 @@
     <div class="form-row p-2">
       <div class="form-group col-md-12 pe-3">
         <%= f.label :name %>
-        <%= f.text_field :name, class:"form-control" %>
+        <%= f.text_field :name, class: "form-control #{'is-invalid' if @tower.errors[:name].any?}" %>
+        <%= render("shared/errors", model: @tower, attribute: :name) if @tower.errors[:name].any? %>
       </div>
     </div>
     
     <div class="form-row d-flex p-2">
       <div class="form-group col-md-6 pe-3">
         <%= f.label :floor_quantity %>
-        <%= f.number_field :floor_quantity, class:"form-control", min: 1, step: 1 %>
+        <%= f.number_field :floor_quantity, class:"form-control #{'is-invalid' if @tower.errors[:floor_quantity].any?}", min: 1, step: 1 %>
+        <%= render("shared/errors", model: @tower, attribute: :floor_quantity) if @tower.errors[:floor_quantity].any? %>
       </div>
       
       <div class="form-group col-md-6 pe-3">
         <%= f.label :units_per_floor %>
-        <%= f.number_field :units_per_floor, class:"form-control", min: 1, step: 1 %>
+        <%= f.number_field :units_per_floor, class:"form-control #{'is-invalid' if @tower.errors[:units_per_floor].any?}", min: 1, step: 1 %>
+        <%= render("shared/errors", model: @tower, attribute: :units_per_floor) if @tower.errors[:units_per_floor].any? %>
       </div>
     </div>
 

--- a/app/views/unit_types/edit.html.erb
+++ b/app/views/unit_types/edit.html.erb
@@ -1,5 +1,3 @@
-<%= render 'shared/errors', model: @unit_type %>
-
 <section class="bg-white rounded-5 py-4 px-5 shadow">
   <h1>Editar Tipo de Unidade</h1>
 
@@ -7,12 +5,15 @@
     <div class="form-row d-flex p-2">
       <div class="form-group col-md-6 pe-3">
         <%= f.label :description %>
-        <%= f.text_area :description, class:"form-control" %>
+        <%= f.text_area :description, class: "form-control #{'is-invalid' if @unit_type.errors[:description].any?}" %>
+        <%= render("shared/errors", model: @unit_type, attribute: :description) if @unit_type.errors[:description].any? %>
       </div>
 
       <div class="form-group col-md-6 pe-3">
         <%= f.label :metreage %>
-        <%= f.number_field :metreage, step: 0.01, class:"form-control" %>
+        <%= f.number_field :metreage, class: "form-control #{'is-invalid' if @unit_type.errors[:metreage].any?}", 
+          placeholder: "50.42", step: 0.01 %>
+        <%= render("shared/errors", model: @unit_type, attribute: :metreage) if @unit_type.errors[:metreage].any? %>
       </div>
     </div>
 

--- a/app/views/unit_types/new.html.erb
+++ b/app/views/unit_types/new.html.erb
@@ -1,5 +1,3 @@
-<%= render 'shared/errors', model: @unit_type %>
-
 <section class='bg-white rounded-5 py-3 px-5 shadow'>
   <h1>Cadastrar um novo tipo de unidade</h1>
 
@@ -7,12 +5,15 @@
     <div class="form-row d-flex p-2">
       <div class="form-group col-md-6 pe-3">
         <%= f.label :description %>
-        <%= f.text_area :description, class: "form-control" %>
+        <%= f.text_area :description, class: "form-control #{'is-invalid' if @unit_type.errors[:description].any?}" %>
+        <%= render("shared/errors", model: @unit_type, attribute: :description) if @unit_type.errors[:description].any? %>
       </div>
 
       <div class="form-group col-md-6 pe-3">
         <%= f.label :metreage %>
-        <%= f.number_field :metreage, step: 0.01, class: "form-control", placeholder: "50.42" %>
+        <%= f.number_field :metreage, class: "form-control #{'is-invalid' if @unit_type.errors[:metreage].any?}", 
+          placeholder: "50.42", step: 0.01 %>
+        <%= render("shared/errors", model: @unit_type, attribute: :metreage) if @unit_type.errors[:metreage].any? %>
       </div>
     </div>
 

--- a/app/views/visitor_entries/new.html.erb
+++ b/app/views/visitor_entries/new.html.erb
@@ -1,19 +1,18 @@
-<%= render "shared/errors", model: @visitor_entry %>
-
 <div class='bg-white rounded-5 py-4 px-5 shadow'>
-
   <h1>Registrar nova entrada</h1>
 
   <%= form_with(model: [@condo, @visitor_entry]) do |f| %>
     <div class="form-row row p-2">
       <div class="form-group col-md-8 pe-3 mb-2">
         <%= f.label :full_name %>
-        <%= f.text_field :full_name , class: 'form-control'%>
+        <%= f.text_field :full_name , class: "form-control #{'is-invalid' if @visitor_entry.errors[:full_name].any?}" %>
+        <%= render("shared/errors", model: @visitor_entry, attribute: :full_name) if @visitor_entry.errors[:full_name].any? %>
       </div>
       
       <div class="form-group col-md-4 pe-3 mb-2">
-        <%= f.label :identity_number%>
-        <%= f.text_field :identity_number, class: 'form-control' %>
+        <%= f.label :identity_number %>
+        <%= f.text_field :identity_number, class: "form-control #{'is-invalid' if @visitor_entry.errors[:identity_number].any?}" %>
+        <%= render("shared/errors", model: @visitor_entry, attribute: :identity_number) if @visitor_entry.errors[:identity_number].any? %>
       </div>
     
       <div class="form-row row m-0 p-0", data-controller="units">

--- a/app/views/visitors/new.html.erb
+++ b/app/views/visitors/new.html.erb
@@ -1,5 +1,3 @@
-<%= render 'shared/errors', model: @visitor %>
-
 <div class="bg-white rounded-5 py-4 px-5 shadow">
     <h1>Cadastrar Visitante/Funcionário</h1>
 
@@ -7,11 +5,13 @@
         <div class="form-row p-2 row">
             <div class="form-group col-md-6 pe-3">
                 <%= f.label :full_name %>
-                <%= f.text_field :full_name, class: 'form-control' %>
+                <%= f.text_field :full_name, class: "form-control #{'is-invalid' if @visitor.errors[:full_name].any?}" %>
+                <%= render("shared/errors", model: @visitor, attribute: :full_name) if @visitor.errors[:full_name].any? %>
             </div>
             <div class="form-group col-md-6 pe-3">
                 <%= f.label :identity_number %>
-                <%= f.text_field :identity_number, class: 'form-control' %>
+                <%= f.text_field :identity_number, class: "form-control #{'is-invalid' if @visitor.errors[:identity_number].any?}" %>
+                <%= render("shared/errors", model: @visitor, attribute: :identity_number) if @visitor.errors[:identity_number].any? %>
             </div>
             <div class="form-row row m-0 p-0" data-controller="hiddenfield">
                 <div class="form-group col-md-6 pe-3">
@@ -20,14 +20,16 @@
                 </div>
                 <div class="form-group col-md-6 pe-3">
                     <%= f.label :visit_date %>
-                    <%= f.date_field :visit_date, class: 'form-control' %>
+                    <%= f.date_field :visit_date, class: "form-control #{'is-invalid' if @visitor.errors[:visit_date].any?}" %>
+                    <%= render("shared/errors", model: @visitor, attribute: :visit_date) if @visitor.errors[:visit_date].any? %>
                 </div>
                 <div class="form-group col-md-6 pe-3 d-none" data-hiddenfield-target="field">
                     <%= f.label :recurrence %>
-                    <%= f.select :recurrence, Visitor.recurrences.keys.map { |recurrence| [I18n.t("activerecord.attributes.visitor.recurrences.#{recurrence}").capitalize, recurrence] }, { prompt: "Selecione uma recorrência" }, class: 'form-control form-select' %>
+                    <%= f.select :recurrence, Visitor.recurrences.keys.map { |recurrence| [I18n.t("activerecord.attributes.visitor.recurrences.#{recurrence}").capitalize, recurrence] },
+                        { prompt: "Selecione uma recorrência" }, class: "form-control form-select #{'is-invalid' if @visitor.errors[:recurrence].any?}" %>
+                    <%= render("shared/errors", model: @visitor, attribute: :recurrence) if @visitor.errors[:recurrence].any? %>
                 </div>
             </div>
-           
         </div>
         
         <div class="d-flex justify-content-center">


### PR DESCRIPTION
Este PR altera a estilização de mensagens de erro em formulários, a partir das sugestões oferecidas na última Sprint Review.

Exemplos de telas:
![image](https://github.com/user-attachments/assets/bf4b200b-5e38-41bf-ba6c-bbd957257af1)
![image](https://github.com/user-attachments/assets/d068bf73-19fe-433d-9b97-be77c89a1ee4)
![image](https://github.com/user-attachments/assets/0750fd70-db57-47eb-b7ba-0cf1731a15c6)
