### PR TITLE
Corrige bugs de timezone

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -33,7 +33,7 @@ module Condominions
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    config.time_zone = "America/Sao_Paulo"
+    config.time_zone = 'America/Sao_Paulo'
 
     config.api = config_for(:api)
     # config.eager_load_paths << Rails.root.join("extras")

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,7 +32,6 @@ module Condominions
     #
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
-    config.active_record.default_timezone = :local
     config.time_zone = 'America/Sao_Paulo'
 
     config.api = config_for(:api)

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,7 +32,7 @@ module Condominions
     #
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
-    #
+    config.active_record.default_timezone = :local
     config.time_zone = 'America/Sao_Paulo'
 
     config.api = config_for(:api)

--- a/spec/factories/superintendents.rb
+++ b/spec/factories/superintendents.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :superintendent do
     condo { build :condo }
     tenant { create(:resident, :with_residence, condo:) }
-    start_date { Time.zone.today }
-    end_date { Time.zone.today >> 6 }
+    start_date { Date.current }
+    end_date { Date.current >> 6 }
   end
 end

--- a/spec/models/superintendent_spec.rb
+++ b/spec/models/superintendent_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Superintendent, type: :model do
     end
 
     it 'end date greater than to start_date' do
-      superintendent = build :superintendent, start_date: Time.zone.today, end_date: Time.zone.today
+      superintendent = build :superintendent, start_date: Date.current, end_date: Date.current
 
       expect(superintendent).not_to be_valid
       expect(superintendent.errors).to include :end_date

--- a/spec/requests/manager_confirms_visitor_spec.rb
+++ b/spec/requests/manager_confirms_visitor_spec.rb
@@ -37,7 +37,7 @@ describe 'Manager confirms visitor' do
 
     it 'successfully only if associated with the condo' do
       manager = create :manager, is_super: false
-      visitor = create :visitor, visit_date: Time.zone.today
+      visitor = create :visitor, visit_date: Date.current
       manager.condos << visitor.condo
 
       login_as manager, scope: :manager
@@ -63,7 +63,7 @@ describe 'Manager confirms visitor' do
     context 'visit_date ' do
       it 'cannot be past' do
         manager = create :manager
-        visitor = create :visitor, visit_date: Time.zone.today
+        visitor = create :visitor, visit_date: Date.current
 
         login_as manager, scope: :manager
         travel_to 1.day.from_now do

--- a/spec/requests/manager_edit_superintendent_spec.rb
+++ b/spec/requests/manager_edit_superintendent_spec.rb
@@ -5,8 +5,8 @@ describe 'Manager edits superintendent' do
     it 'must be authenticated to edit an superintendent' do
       condo = create :condo, name: 'Condomínio X'
       resident = create(:resident, :with_residence, condo:)
-      superintendent = create(:superintendent, condo:, tenant: resident, start_date: Time.zone.today,
-                                               end_date: Time.zone.today >> 2)
+      superintendent = create(:superintendent, condo:, tenant: resident, start_date: Date.current,
+                                               end_date: Date.current >> 2)
 
       get edit_condo_superintendent_path(condo, superintendent)
 
@@ -17,8 +17,8 @@ describe 'Manager edits superintendent' do
       condo_manager = create :manager, is_super: false
       condo = create :condo, name: 'Condomínio X'
       resident = create(:resident, :with_residence, condo:)
-      superintendent = create(:superintendent, condo:, tenant: resident, start_date: Time.zone.today,
-                                               end_date: Time.zone.today >> 2)
+      superintendent = create(:superintendent, condo:, tenant: resident, start_date: Date.current,
+                                               end_date: Date.current >> 2)
 
       login_as condo_manager, scope: :manager
 
@@ -30,8 +30,8 @@ describe 'Manager edits superintendent' do
     it 'must be authenticated as manager' do
       condo = create :condo, name: 'Condomínio X'
       resident = create(:resident, :with_residence, condo:)
-      superintendent = create(:superintendent, condo:, tenant: resident, start_date: Time.zone.today,
-                                               end_date: Time.zone.today >> 2)
+      superintendent = create(:superintendent, condo:, tenant: resident, start_date: Date.current,
+                                               end_date: Date.current >> 2)
 
       login_as resident, scope: :resident
 
@@ -46,8 +46,8 @@ describe 'Manager edits superintendent' do
       condo = create :condo, name: 'Condomínio X'
       resident = create(:resident, :with_residence, condo:)
       resident2 = create(:resident, :with_residence, email: 'Adrolado@email.com', condo:)
-      superintendent = create(:superintendent, condo:, tenant: resident, start_date: Time.zone.today,
-                                               end_date: Time.zone.today >> 2)
+      superintendent = create(:superintendent, condo:, tenant: resident, start_date: Date.current,
+                                               end_date: Date.current >> 2)
 
       params = { superintendent: { tenant_id: resident2.id }, condo_id: condo.id }
 
@@ -61,8 +61,8 @@ describe 'Manager edits superintendent' do
       condo = create :condo, name: 'Condomínio X'
       resident = create(:resident, :with_residence, condo:)
       resident2 = create(:resident, :with_residence, email: 'Adrolado@email.com', condo:)
-      superintendent = create(:superintendent, condo:, tenant: resident, start_date: Time.zone.today,
-                                               end_date: Time.zone.today >> 2)
+      superintendent = create(:superintendent, condo:, tenant: resident, start_date: Date.current,
+                                               end_date: Date.current >> 2)
 
       condo_manager = create :manager, is_super: false
       login_as condo_manager, scope: :manager
@@ -79,8 +79,8 @@ describe 'Manager edits superintendent' do
       condo = create :condo, name: 'Condomínio X'
       resident = create(:resident, :with_residence, condo:)
       resident2 = create(:resident, :with_residence, email: 'Adrolado@email.com', condo:)
-      superintendent = create(:superintendent, condo:, tenant: resident, start_date: Time.zone.today,
-                                               end_date: Time.zone.today >> 2)
+      superintendent = create(:superintendent, condo:, tenant: resident, start_date: Date.current,
+                                               end_date: Date.current >> 2)
 
       login_as resident, scope: :resident
 

--- a/spec/requests/manager_registers_superintendent_spec.rb
+++ b/spec/requests/manager_registers_superintendent_spec.rb
@@ -38,7 +38,7 @@ describe 'Manager registers superintendent' do
       condo = create :condo
       resident = create(:resident, :with_residence, condo:)
 
-      params = { superintendent: { start_date: Time.zone.today, end_date: Time.zone.today >> 2,
+      params = { superintendent: { start_date: Date.current, end_date: Date.current >> 2,
                                    tenant_id: resident.id }, condo_id: condo.id }
 
       post(condo_superintendents_path(condo), params:)
@@ -54,7 +54,7 @@ describe 'Manager registers superintendent' do
 
       login_as condo_manager, scope: :manager
 
-      params = { superintendent: { start_date: Time.zone.today, end_date: Time.zone.today >> 2,
+      params = { superintendent: { start_date: Date.current, end_date: Date.current >> 2,
                                    tenant_id: resident.id }, condo_id: condo.id }
 
       post(condo_superintendents_path(condo), params:)
@@ -69,7 +69,7 @@ describe 'Manager registers superintendent' do
 
       login_as resident, scope: :resident
 
-      params = { superintendent: { start_date: Time.zone.today, end_date: Time.zone.today >> 2,
+      params = { superintendent: { start_date: Date.current, end_date: Date.current >> 2,
                                    tenant_id: resident.id }, condo_id: condo.id }
 
       post(condo_superintendents_path(condo), params:)

--- a/spec/system/superintendent/manager_edit_superintendent_spec.rb
+++ b/spec/system/superintendent/manager_edit_superintendent_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe 'Manager edit superintendent' do
-  it 'succesfully' do
+  it 'successfully' do
     condo = create :condo, name: 'Condomínio X'
     resident = create(:resident, :with_residence, full_name: 'Dona Alvara', condo:)
     resident2 = create(:resident, :with_residence, full_name: 'Havana Silva', email: 'email@email.com', condo:)
@@ -16,14 +16,14 @@ describe 'Manager edit superintendent' do
     visit condo_path condo
     click_on 'Dona Alvara'
     click_on 'Editar Síndico'
-    fill_in 'Data de conclusão', with: Time.zone.today >> 30
+    fill_in 'Data de conclusão', with: Date.current >> 1
     select 'Havana Silva', from: 'Morador'
     click_on 'Enviar'
 
     superintendent.reload
     expect(page).to have_content 'Mandato de síndico atualizado com sucesso!'
     expect(current_path).to eq condo_superintendent_path(condo, Superintendent.last)
-    expect(superintendent.end_date).to eq Time.zone.today >> 30
+    expect(superintendent.end_date).to eq Date.current >> 1
     expect(superintendent.tenant).to eq resident2
     expect(resident.superintendent).to eq nil
   end
@@ -31,7 +31,7 @@ describe 'Manager edit superintendent' do
   it 'with missing params' do
     condo = create :condo, name: 'Condomínio X'
     resident = create(:resident, :with_residence, full_name: 'Dona Alvara', condo:)
-    create(:superintendent, tenant: resident, condo:, start_date: Time.zone.today, end_date: Time.zone.today >> 2)
+    create(:superintendent, tenant: resident, condo:, start_date: Date.current, end_date: Date.current >> 2)
     manager = create :manager
 
     resident.user_image.attach(io: Rails.root.join('spec/support/images/resident_photo.jpg').open,
@@ -45,6 +45,6 @@ describe 'Manager edit superintendent' do
     click_on 'Enviar'
 
     expect(page).to have_content 'Não foi possível atualizar o mandato.'
-    expect(Superintendent.last.end_date).to eq Time.zone.today >> 2
+    expect(Superintendent.last.end_date).to eq Date.current >> 2
   end
 end

--- a/spec/system/superintendent/manager_edit_superintendent_spec.rb
+++ b/spec/system/superintendent/manager_edit_superintendent_spec.rb
@@ -6,7 +6,8 @@ describe 'Manager edit superintendent' do
     resident = create(:resident, :with_residence, full_name: 'Dona Alvara', condo:)
     resident2 = create(:resident, :with_residence, full_name: 'Havana Silva', email: 'email@email.com', condo:)
     travel_to '2024-07-21'.to_date
-    superintendent = create(:superintendent, tenant: resident, condo:, start_date: '2024-07-21'.to_date, end_date: '2024-07-25'.to_date)
+    superintendent = create(:superintendent, tenant: resident, condo:, start_date: '2024-07-21'.to_date,
+                                             end_date: '2024-07-25'.to_date)
 
     manager = create :manager
 
@@ -32,7 +33,9 @@ describe 'Manager edit superintendent' do
   it 'with missing params' do
     condo = create :condo, name: 'Condomínio X'
     resident = create(:resident, :with_residence, full_name: 'Dona Alvara', condo:)
-    create(:superintendent, tenant: resident, condo:, start_date: Date.current, end_date: Date.current >> 2)
+    travel_to '2024-07-21'.to_date
+    create(:superintendent, tenant: resident, condo:, start_date: '2024-07-21'.to_date,
+                            end_date: '2024-07-25'.to_date)
     manager = create :manager
 
     resident.user_image.attach(io: Rails.root.join('spec/support/images/resident_photo.jpg').open,
@@ -45,8 +48,7 @@ describe 'Manager edit superintendent' do
     fill_in 'Data de conclusão', with: ''
     click_on 'Enviar'
 
-    wait
     expect(page).to have_content 'Não foi possível atualizar o mandato.'
-    expect(Superintendent.last.end_date).to eq Date.current >> 2
+    expect(Superintendent.last.end_date).to eq '2024-07-25'.to_date
   end
 end

--- a/spec/system/superintendent/manager_edit_superintendent_spec.rb
+++ b/spec/system/superintendent/manager_edit_superintendent_spec.rb
@@ -5,7 +5,8 @@ describe 'Manager edit superintendent' do
     condo = create :condo, name: 'Condomínio X'
     resident = create(:resident, :with_residence, full_name: 'Dona Alvara', condo:)
     resident2 = create(:resident, :with_residence, full_name: 'Havana Silva', email: 'email@email.com', condo:)
-    superintendent = create(:superintendent, tenant: resident, condo:)
+    travel_to '2024-07-21'.to_date
+    superintendent = create(:superintendent, tenant: resident, condo:, start_date: '2024-07-21'.to_date, end_date: '2024-07-25'.to_date)
 
     manager = create :manager
 
@@ -16,14 +17,14 @@ describe 'Manager edit superintendent' do
     visit condo_path condo
     click_on 'Dona Alvara'
     click_on 'Editar Síndico'
-    fill_in 'Data de conclusão', with: Date.current >> 1
+    fill_in 'Data de conclusão', with: '2024-07-25'.to_date
     select 'Havana Silva', from: 'Morador'
     click_on 'Enviar'
 
     superintendent.reload
     expect(page).to have_content 'Mandato de síndico atualizado com sucesso!'
     expect(current_path).to eq condo_superintendent_path(condo, Superintendent.last)
-    expect(superintendent.end_date).to eq Date.current >> 1
+    expect(superintendent.end_date).to eq '2024-07-25'.to_date
     expect(superintendent.tenant).to eq resident2
     expect(resident.superintendent).to eq nil
   end
@@ -44,6 +45,7 @@ describe 'Manager edit superintendent' do
     fill_in 'Data de conclusão', with: ''
     click_on 'Enviar'
 
+    wait
     expect(page).to have_content 'Não foi possível atualizar o mandato.'
     expect(Superintendent.last.end_date).to eq Date.current >> 2
   end

--- a/spec/system/superintendent/manager_register_superintendent_spec.rb
+++ b/spec/system/superintendent/manager_register_superintendent_spec.rb
@@ -5,7 +5,7 @@ describe 'Manager register superintendent' do
     condo = create :condo, name: 'Condomínio X'
     resident = create(:resident, :with_residence, full_name: 'Alvus Dumbledore', condo:)
     manager = create :manager
-    date = Time.zone.today
+    date = Date.current
 
     login_as manager, scope: :manager
     visit root_path

--- a/spec/system/superintendent/manager_register_superintendent_spec.rb
+++ b/spec/system/superintendent/manager_register_superintendent_spec.rb
@@ -5,7 +5,7 @@ describe 'Manager register superintendent' do
     condo = create :condo, name: 'Condomínio X'
     resident = create(:resident, :with_residence, full_name: 'Alvus Dumbledore', condo:)
     manager = create :manager
-    date = Date.current
+    travel_to '2024-07-21'.to_date
 
     login_as manager, scope: :manager
     visit root_path
@@ -17,8 +17,8 @@ describe 'Manager register superintendent' do
     within '#condoSelectPopupForSuperintendent' do
       click_on 'Condomínio X'
     end
-    fill_in 'Data de ínicio', with: date
-    fill_in 'Data de conclusão', with: date >> 12
+    fill_in 'Data de ínicio', with: '2024-07-21'.to_date
+    fill_in 'Data de conclusão', with: '2025-07-21'.to_date
     select 'Alvus Dumbledore', from: 'Morador'
     click_on 'Enviar'
 

--- a/spec/system/superintendent/user_sees_superintendent_details_spec.rb
+++ b/spec/system/superintendent/user_sees_superintendent_details_spec.rb
@@ -7,8 +7,8 @@ describe 'User sees superintendent details' do
       tower = create(:tower, condo:)
       unit11 = tower.floors.first.units.first
       resident = create :resident, full_name: 'Dona Alvara', residence: unit11, email: 'alvara@email.com'
-      create(:superintendent, condo:, tenant: resident, start_date: Time.zone.today,
-                              end_date: Time.zone.today >> 2)
+      create(:superintendent, condo:, tenant: resident, start_date: Date.current,
+                              end_date: Date.current >> 2)
       manager = create :manager
 
       resident.user_image.attach(io: Rails.root.join('spec/support/images/resident_photo.jpg').open,
@@ -26,8 +26,8 @@ describe 'User sees superintendent details' do
         expect(page).to have_content 'Condomínio X'
         expect(page).to have_content 'Torre A'
         expect(page).to have_content 'Unidade: 11'
-        expect(page).to have_content I18n.l Time.zone.today
-        expect(page).to have_content I18n.l(Time.zone.today >> 2)
+        expect(page).to have_content I18n.l Date.current
+        expect(page).to have_content I18n.l(Date.current >> 2)
       end
       expect(page).to have_button 'Editar Síndico'
     end
@@ -52,8 +52,8 @@ describe 'User sees superintendent details' do
       tower = create(:tower, condo:)
       unit11 = tower.floors.first.units.first
       resident = create :resident, full_name: 'Dona Alvara', residence: unit11, email: 'alvara@email.com'
-      superintendent = create(:superintendent, condo:, tenant: resident, start_date: Time.zone.today,
-                                               end_date: Time.zone.today >> 2)
+      superintendent = create(:superintendent, condo:, tenant: resident, start_date: Date.current,
+                                               end_date: Date.current >> 2)
       resident.user_image.attach(io: Rails.root.join('spec/support/images/resident_photo.jpg').open,
                                  filename: 'resident_photo.jpg')
 
@@ -70,8 +70,8 @@ describe 'User sees superintendent details' do
         expect(page).to have_content 'Condomínio X'
         expect(page).to have_content 'Torre A'
         expect(page).to have_content 'Unidade: 11'
-        expect(page).to have_content I18n.l Time.zone.today
-        expect(page).to have_content I18n.l(Time.zone.today >> 2)
+        expect(page).to have_content I18n.l Date.current
+        expect(page).to have_content I18n.l(Date.current >> 2)
       end
 
       expect(page).not_to have_button 'Editar Síndico'

--- a/spec/system/superintendent/user_sees_superintendent_details_spec.rb
+++ b/spec/system/superintendent/user_sees_superintendent_details_spec.rb
@@ -7,8 +7,9 @@ describe 'User sees superintendent details' do
       tower = create(:tower, condo:)
       unit11 = tower.floors.first.units.first
       resident = create :resident, full_name: 'Dona Alvara', residence: unit11, email: 'alvara@email.com'
-      create(:superintendent, condo:, tenant: resident, start_date: Date.current,
-                              end_date: Date.current >> 2)
+      travel_to '2024-07-21'.to_date
+      create(:superintendent, tenant: resident, condo:, start_date: '2024-07-21'.to_date,
+                              end_date: '2024-07-25'.to_date)
       manager = create :manager
 
       resident.user_image.attach(io: Rails.root.join('spec/support/images/resident_photo.jpg').open,
@@ -26,8 +27,8 @@ describe 'User sees superintendent details' do
         expect(page).to have_content 'Condomínio X'
         expect(page).to have_content 'Torre A'
         expect(page).to have_content 'Unidade: 11'
-        expect(page).to have_content I18n.l Date.current
-        expect(page).to have_content I18n.l(Date.current >> 2)
+        expect(page).to have_content I18n.l('2024-07-21'.to_date)
+        expect(page).to have_content I18n.l('2024-07-25'.to_date)
       end
       expect(page).to have_button 'Editar Síndico'
     end
@@ -52,8 +53,9 @@ describe 'User sees superintendent details' do
       tower = create(:tower, condo:)
       unit11 = tower.floors.first.units.first
       resident = create :resident, full_name: 'Dona Alvara', residence: unit11, email: 'alvara@email.com'
-      superintendent = create(:superintendent, condo:, tenant: resident, start_date: Date.current,
-                                               end_date: Date.current >> 2)
+      travel_to '2024-07-21'.to_date
+      superintendent = create(:superintendent, tenant: resident, condo:, start_date: '2024-07-21'.to_date,
+                                               end_date: '2024-07-25'.to_date)
       resident.user_image.attach(io: Rails.root.join('spec/support/images/resident_photo.jpg').open,
                                  filename: 'resident_photo.jpg')
 
@@ -70,8 +72,8 @@ describe 'User sees superintendent details' do
         expect(page).to have_content 'Condomínio X'
         expect(page).to have_content 'Torre A'
         expect(page).to have_content 'Unidade: 11'
-        expect(page).to have_content I18n.l Date.current
-        expect(page).to have_content I18n.l(Date.current >> 2)
+        expect(page).to have_content I18n.l('2024-07-21'.to_date)
+        expect(page).to have_content I18n.l('2024-07-25'.to_date)
       end
 
       expect(page).not_to have_button 'Editar Síndico'

--- a/spec/system/visitor/manager_view_condo_full_visitors_list_spec.rb
+++ b/spec/system/visitor/manager_view_condo_full_visitors_list_spec.rb
@@ -10,14 +10,14 @@ describe 'Manager view condo full visitors list' do
     second_resident = create :resident, full_name: 'Maria Silveira', residence: tower.floors[0].units[1]
     first_visitor = create :visitor, condo: first_condo,
                                      resident: first_resident,
-                                     visit_date: Time.zone.today,
+                                     visit_date: Date.current,
                                      full_name: 'João da Silva',
                                      identity_number: '12467'
     second_visitor = create :visitor, condo: first_condo,
                                       resident: first_resident,
                                       category: :employee,
                                       recurrence: :weekly,
-                                      visit_date: Time.zone.today,
+                                      visit_date: Date.current,
                                       full_name: 'Maria Oliveira',
                                       identity_number: '45977'
     third_visitor = create :visitor, condo: first_condo,
@@ -26,7 +26,7 @@ describe 'Manager view condo full visitors list' do
                                      full_name: 'Marcos Lima',
                                      identity_number: '12345'
     fourth_visitor = create :visitor, condo: second_condo,
-                                      visit_date: Time.zone.today,
+                                      visit_date: Date.current,
                                       full_name: 'Juliana Ferreira'
 
     login_as manager, scope: :manager
@@ -41,7 +41,7 @@ describe 'Manager view condo full visitors list' do
       expect(page).to have_content 'Visitante'
       expect(page).to have_content 'Torre A - 11'
       expect(page).to have_content 'Alberto Silveira'
-      expect(page).to have_content I18n.l(Time.zone.today)
+      expect(page).to have_content I18n.l(Date.current)
     end
     within("#visitor-#{second_visitor.id}") do
       expect(page).to have_content 'Maria Oliveira'
@@ -49,7 +49,7 @@ describe 'Manager view condo full visitors list' do
       expect(page).to have_content 'Funcionário'
       expect(page).to have_content 'Torre A - 11'
       expect(page).to have_content 'Alberto Silveira'
-      expect(page).to have_content I18n.l(Time.zone.today)
+      expect(page).to have_content I18n.l(Date.current)
       expect(page).to have_content 'Semanal'
     end
     within("#visitor-#{third_visitor.id}") do

--- a/spec/system/visitor/manager_view_condo_visitors_list_spec.rb
+++ b/spec/system/visitor/manager_view_condo_visitors_list_spec.rb
@@ -8,19 +8,19 @@ describe 'Manager view condo visitors list' do
     first_condo = create :condo
     second_condo = create :condo
     first_visitor = create :visitor, condo: first_condo, resident:,
-                                     visit_date: Time.zone.today, full_name: 'João da Silva', identity_number: '12467'
+                                     visit_date: Date.current, full_name: 'João da Silva', identity_number: '12467'
     second_visitor = create :visitor, condo: first_condo, resident:,
-                                      visit_date: Time.zone.today, full_name: 'Maria Oliveira', identity_number: '45977'
+                                      visit_date: Date.current, full_name: 'Maria Oliveira', identity_number: '45977'
     third_visitor = create :visitor, condo: first_condo,
                                      visit_date: 1.day.from_now, full_name: 'Marcos Lima'
     fourth_visitor = create :visitor, condo: second_condo,
-                                      visit_date: Time.zone.today, full_name: 'Juliana Ferreira'
+                                      visit_date: Date.current, full_name: 'Juliana Ferreira'
 
     login_as manager, scope: :manager
     visit condo_path first_condo
     click_on 'Agenda de visitantes/funcionários'
 
-    expect(page).to have_content I18n.l(Time.zone.today, format: :long)
+    expect(page).to have_content I18n.l(Date.current, format: :long)
     within("#visitor-#{first_visitor.id}") do
       expect(page).to have_content 'Alberto Silveira'
       expect(page).to have_content 'João da Silva'
@@ -50,7 +50,7 @@ describe 'Manager view condo visitors list' do
     second_visitor = create :visitor, condo: first_condo, resident:,
                                       visit_date: 1.day.from_now, full_name: 'Maria Oliveira', identity_number: '45977'
     third_visitor = create :visitor, condo: first_condo, resident:,
-                                     visit_date: Time.zone.today, full_name: 'Marcos Lima'
+                                     visit_date: Date.current, full_name: 'Marcos Lima'
     fourth_visitor = create :visitor, condo: second_condo,
                                       visit_date: 1.day.from_now, full_name: 'Juliana Ferreira'
 
@@ -58,7 +58,7 @@ describe 'Manager view condo visitors list' do
     visit find_condo_visitors_path first_condo
     click_on 'Dia Seguinte'
 
-    expect(page).to have_content I18n.l(Time.zone.today + 1.day, format: :long)
+    expect(page).to have_content I18n.l(Date.current + 1.day, format: :long)
     within("#visitor-#{first_visitor.id}") do
       expect(page).to have_content 'Alberto Silveira'
       expect(page).to have_content 'João da Silva'
@@ -84,19 +84,19 @@ describe 'Manager view condo visitors list' do
     first_condo = create :condo
     second_condo = create :condo
     first_visitor = create :visitor, condo: first_condo, resident:,
-                                     visit_date: Time.zone.today, full_name: 'João da Silva', identity_number: '12467'
+                                     visit_date: Date.current, full_name: 'João da Silva', identity_number: '12467'
     second_visitor = create :visitor, condo: first_condo, resident:,
-                                      visit_date: Time.zone.today, full_name: 'Maria Oliveira', identity_number: '45977'
+                                      visit_date: Date.current, full_name: 'Maria Oliveira', identity_number: '45977'
     third_visitor = create :visitor, condo: first_condo, resident:,
                                      visit_date: 1.day.from_now, full_name: 'Marcos Lima'
     fourth_visitor = create :visitor, condo: second_condo,
-                                      visit_date: Time.zone.today, full_name: 'Juliana Ferreira'
+                                      visit_date: Date.current, full_name: 'Juliana Ferreira'
 
     login_as manager, scope: :manager
     visit find_condo_visitors_path(first_condo, date: 1.day.from_now)
     click_on 'Dia Anterior'
 
-    expect(page).to have_content I18n.l(Time.zone.today, format: :long)
+    expect(page).to have_content I18n.l(Date.current, format: :long)
     within("#visitor-#{first_visitor.id}") do
       expect(page).to have_content 'Alberto Silveira'
       expect(page).to have_content 'João da Silva'
@@ -125,7 +125,7 @@ describe 'Manager view condo visitors list' do
 
     expect(page).to have_content 'Não é possível acessar uma data passada'
     expect(current_path).to eq find_condo_visitors_path(condo)
-    expect(page).to have_content I18n.l(Time.zone.today, format: :long)
+    expect(page).to have_content I18n.l(Date.current, format: :long)
   end
 
   it 'must be authenticated' do
@@ -163,7 +163,7 @@ describe 'Manager view condo visitors list' do
       manager = create :manager
       condo = create :condo
       resident = create(:resident, :with_residence, condo:)
-      visitor = create :visitor, condo:, resident:, visit_date: Time.zone.today, full_name: 'João Almeida'
+      visitor = create :visitor, condo:, resident:, visit_date: Date.current, full_name: 'João Almeida'
 
       login_as manager, scope: :manager
       visit find_condo_visitors_path condo

--- a/spec/system/visitor/resident_sees_own_visitors_list_spec.rb
+++ b/spec/system/visitor/resident_sees_own_visitors_list_spec.rb
@@ -97,11 +97,11 @@ describe 'Resident sees own visitors list' do
       second_resident_visitor = create :visitor, resident: second_resident, full_name: 'Fernando Dias'
       first_visitor = create :visitor, resident:,
                                        full_name: 'João Ferreira',
-                                       visit_date: Time.zone.today,
+                                       visit_date: Date.current,
                                        category: :visitor
       second_visitor = create :visitor, resident:,
                                         full_name: 'Maria Almeida',
-                                        visit_date: Time.zone.today,
+                                        visit_date: Date.current,
                                         category: :employee, recurrence: :daily
       third_visitor = create :visitor, resident:,
                                        full_name: 'João Almeida',

--- a/spec/system/visitor_entry/manager_see_visitor_entries_spec.rb
+++ b/spec/system/visitor_entry/manager_see_visitor_entries_spec.rb
@@ -107,7 +107,6 @@ describe 'manager see visitor entries list' do
       travel_to '05/07/2024 00:30' do
         create :visitor_entry, condo:, full_name: 'Nome Último Visitante'
 
-
         login_as manager, scope: :manager
         visit condo_visitor_entries_path condo
         fill_in 'Data da Visita', with: '2024-07-05'

--- a/spec/system/visitor_entry/manager_see_visitor_entries_spec.rb
+++ b/spec/system/visitor_entry/manager_see_visitor_entries_spec.rb
@@ -96,21 +96,28 @@ describe 'manager see visitor entries list' do
     it 'with visit date filter' do
       manager = create :manager
       condo = create :condo
-      travel_to 1.day.ago do
+      travel_to '04/07/2024' do
         create :visitor_entry, condo:, full_name: 'Nome Visitante Ontem'
       end
-      create :visitor_entry, condo:, full_name: 'Nome Primeiro Visitante'
-      create :visitor_entry, condo:, full_name: 'Nome Último Visitante'
 
-      login_as manager, scope: :manager
-      visit condo_visitor_entries_path condo
-      fill_in 'Data da Visita', with: Time.zone.today
-      click_on 'Pesquisar'
+      travel_to '05/07/2024' do
+        create :visitor_entry, condo:, full_name: 'Nome Primeiro Visitante'
+      end
 
-      expect(page).to have_content '2 entradas de visitante encontrada'
-      within('.table > tbody > tr:nth-child(1)') { expect(page).to have_content 'Nome Último Visitante' }
-      within('.table > tbody > tr:nth-child(2)') { expect(page).to have_content 'Nome Primeiro Visitante' }
-      expect(page).not_to have_content 'Nome Visitante Ontem'
+      travel_to '05/07/2024 00:30' do
+        create :visitor_entry, condo:, full_name: 'Nome Último Visitante'
+
+
+        login_as manager, scope: :manager
+        visit condo_visitor_entries_path condo
+        fill_in 'Data da Visita', with: '2024-07-05'
+        click_on 'Pesquisar'
+
+        expect(page).to have_content '2 entradas de visitante encontrada'
+        within('.table > tbody > tr:nth-child(1)') { expect(page).to have_content 'Nome Último Visitante' }
+        within('.table > tbody > tr:nth-child(2)') { expect(page).to have_content 'Nome Primeiro Visitante' }
+        expect(page).not_to have_content 'Nome Visitante Ontem'
+      end
     end
 
     it 'with identity number filter' do
@@ -130,23 +137,25 @@ describe 'manager see visitor entries list' do
     end
 
     it 'with all filters' do
-      manager = create :manager
-      condo = create :condo
-      create :visitor_entry, condo:, full_name: 'Nome Primeiro Visitante', identity_number: '145697'
-      create :visitor_entry, condo:, full_name: 'Nome Segundo Visitante', identity_number: '789354'
-      create :visitor_entry, condo:, full_name: 'Nome Terceiro Visitante', identity_number: '78935447'
+      travel_to '05/07/2024' do
+        manager = create :manager
+        condo = create :condo
+        create :visitor_entry, condo:, full_name: 'Nome Primeiro Visitante', identity_number: '145697'
+        create :visitor_entry, condo:, full_name: 'Nome Segundo Visitante', identity_number: '789354'
+        create :visitor_entry, condo:, full_name: 'Nome Terceiro Visitante', identity_number: '78935447'
 
-      login_as manager, scope: :manager
-      visit condo_visitor_entries_path condo
-      fill_in 'Nome Completo', with: 'Segundo'
-      fill_in 'RG', with: '789354'
-      fill_in 'Data da Visita', with: Time.zone.today
-      click_on 'Pesquisar'
+        login_as manager, scope: :manager
+        visit condo_visitor_entries_path condo
+        fill_in 'Nome Completo', with: 'Segundo'
+        fill_in 'RG', with: '789354'
+        fill_in 'Data da Visita', with: '2024-07-05'
+        click_on 'Pesquisar'
 
-      expect(page).to have_content '1 entrada de visitante encontrada'
-      within('.table > tbody > tr:nth-child(1)') { expect(page).to have_content 'Nome Segundo Visitante' }
-      expect(page).not_to have_content 'Nome Primeiro Visitante'
-      expect(page).not_to have_content 'Nome Terceiro Visitante'
+        expect(page).to have_content '1 entrada de visitante encontrada'
+        within('.table > tbody > tr:nth-child(1)') { expect(page).to have_content 'Nome Segundo Visitante' }
+        expect(page).not_to have_content 'Nome Primeiro Visitante'
+        expect(page).not_to have_content 'Nome Terceiro Visitante'
+      end
     end
 
     it 'with no filters' do


### PR DESCRIPTION
### Descrição
Os testes main foram quebrados aparentemente por bugs causados por uso indevido de datas dinâmicas. Substituímos os `Time.zone.today` por `Date.current` e usamos `travel_to` com datas fixas nos testes que quebraram.