### PR TITLE
Gera cancelamento de cobrança na aplicação PagueAluguel

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -22,12 +22,14 @@ class ReservationsController < ApplicationController
     return redirect_to @common_area, notice: t('notices.reservation.canceled') if cancel_reservation
 
     redirect_to @common_area, alert: t('alerts.reservation.cancelation_failed')
+  rescue Faraday::ConnectionFailed
+    redirect_to @common_area, alert: t('alerts.lost_connection')
   end
 
   private
 
   def cancel_reservation
-    Time.zone.today < @reservation.date && @reservation.canceled!
+    Time.zone.today < @reservation.date && @reservation.cancel_single_charge.status == 200 && @reservation.canceled!
   end
 
   def resident_access_restricted?

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -7,9 +7,16 @@ class Reservation < ApplicationRecord
   validates :date, presence: true
   validate :check_availability, :date_must_be_actual_or_future, on: :create
 
+  def cancel_single_charge
+    url = "#{Rails.configuration.api['base_url']}/single_charges/#{single_charge_id}/cancel"
+    Faraday.patch(url)
+  end
+
   def generate_single_charge
     url = "#{Rails.configuration.api['base_url']}/single_charges/"
-    Faraday.post(url, single_charge_json, 'Content-Type' => 'application/json')
+    response = Faraday.post(url, single_charge_json, 'Content-Type' => 'application/json')
+    self.single_charge_id = JSON.parse(response.body)['single_charge_id']
+    response
   end
 
   def single_charge_json

--- a/db/migrate/20240722025316_add_single_charge_id_to_reservations.rb
+++ b/db/migrate/20240722025316_add_single_charge_id_to_reservations.rb
@@ -1,0 +1,5 @@
+class AddSingleChargeIdToReservations < ActiveRecord::Migration[7.1]
+  def change
+    add_column :reservations, :single_charge_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_18_231004) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_22_025316) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
     t.text "body"
@@ -131,6 +131,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_18_231004) do
     t.integer "resident_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "single_charge_id"
     t.index ["common_area_id"], name: "index_reservations_on_common_area_id"
     t.index ["resident_id"], name: "index_reservations_on_resident_id"
   end

--- a/spec/support/json/common_areas/single_charge_cancelation.json
+++ b/spec/support/json/common_areas/single_charge_cancelation.json
@@ -1,0 +1,3 @@
+{
+  "message": "cancelado"
+}

--- a/spec/system/common_area/reservation/resident_cancel_common_area_reservation_spec.rb
+++ b/spec/system/common_area/reservation/resident_cancel_common_area_reservation_spec.rb
@@ -5,11 +5,15 @@ describe 'Resident cancel common area reservation' do
     common_area = create :common_area
     resident = create :resident, :with_residence, condo: common_area.condo
 
+    patch_data = Rails.root.join('spec/support/json/common_areas/single_charge_cancelation.json').read
+    allow(Faraday).to receive(:patch).and_return(double('response', body: patch_data, success?: true, status: 200))
+
     travel_to '01/07/2024' do
       reservation = create :reservation,
                            common_area:,
                            resident:,
                            date: '05/07/2024',
+                           single_charge_id: 1,
                            status: :confirmed
 
       login_as resident, scope: :resident
@@ -34,7 +38,7 @@ describe 'Resident cancel common area reservation' do
     resident = create :resident, :with_residence, condo: common_area.condo
 
     travel_to '03/07/2024' do
-      create :reservation, common_area:, resident:, date: '03/07/2024', status: :confirmed
+      create :reservation, common_area:, resident:, date: '03/07/2024', single_charge_id: 1, status: :confirmed
     end
 
     travel_to '05/07/2024' do
@@ -45,6 +49,37 @@ describe 'Resident cancel common area reservation' do
         expect(page).to have_content 'Reservado'
         expect(page).not_to have_button 'Cancelar'
       end
+    end
+  end
+
+  it 'fail if the connection is lost with external application' do
+    common_area = create :common_area
+    resident = create :resident, :with_residence, condo: common_area.condo
+
+    travel_to '01/07/2024' do
+      reservation = create :reservation,
+                           common_area:,
+                           resident:,
+                           date: '05/07/2024',
+                           single_charge_id: 1,
+                           status: :confirmed
+
+      login_as resident, scope: :resident
+      visit common_area_path common_area
+
+      within('.table > tbody > tr:nth-child(1) > .wday-5') do
+        accept_confirm { click_on 'Cancelar' }
+        reservation.reload
+
+        expect(page).to have_content 'Reservado'
+        expect(page).to have_button 'Cancelar'
+        expect(page).not_to have_button 'Reservar'
+      end
+
+      expect(page).to have_content 'Conexão perdida com o servidor do PagueAluguel'
+      expect(page).not_to have_content 'Reserva cancelada com sucesso'
+      expect(current_path).to eq common_area_path common_area
+      expect(reservation.canceled?).to be false
     end
   end
 end

--- a/spec/system/common_area/reservation/resident_reserves_common_area_spec.rb
+++ b/spec/system/common_area/reservation/resident_reserves_common_area_spec.rb
@@ -35,6 +35,7 @@ describe 'Resident reserves common area' do
 
     expect(Reservation.last.resident).to eq first_resident
     expect(common_area.reservations.last.date).to eq Date.new(2024, 7, 5)
+    expect(common_area.reservations.last.single_charge_id).to eq 1
   end
 
   it 'fail if the connection is lost with external application' do


### PR DESCRIPTION
### Introdução
Quando o morador cancela uma reserva, a cobrança avulsa no PagueAluguel é cancelada.

### Objetivo
- Garantir que a cobrança avulsa seja cancelada a menos que a conexão com o PagueAluguel falhe, caso em que o morador vê uma mensagem de erro e o cancelamento não é concluído.

### Views
- Visualização da cobrança ativa
![image](https://github.com/user-attachments/assets/50782116-099f-47b2-94ac-d923e9bdb15c)

- Visualização da cobrança cancelada
![image](https://github.com/user-attachments/assets/35d3e49f-2385-4e27-8c7f-256eeeb30e58)

