### PR TITLE
Ajusta erro na query em horario critico

### DIFF
--- a/app/controllers/visitor_entries_controller.rb
+++ b/app/controllers/visitor_entries_controller.rb
@@ -10,7 +10,7 @@ class VisitorEntriesController < ApplicationController
 
     @result = []
     params.permit(:full_name, :visit_date, :identity_number).each do |key, value|
-      key = 'created_at' if key == 'visit_date'
+      key = 'database_datetime' if key == 'visit_date'
       @result << find_visitor_entries(key, value) if value.present?
     end
 

--- a/app/models/visitor_entry.rb
+++ b/app/models/visitor_entry.rb
@@ -8,4 +8,12 @@ class VisitorEntry < ApplicationRecord
   validates :identity_number, length: { in: 5..10 }
   validates :identity_number,
             format: { with: ID_REGEX, message: I18n.t('alerts.visitor_entry.only_numbers_and_letters') }
+
+  before_save :set_database_datetime
+
+  private
+
+  def set_database_datetime
+    self.database_datetime ||= (DateTime.now + Time.zone.utc_offset.seconds)
+  end
 end

--- a/db/migrate/20240722105115_add_database_datetime_to_visitor_entry.rb
+++ b/db/migrate/20240722105115_add_database_datetime_to_visitor_entry.rb
@@ -1,0 +1,5 @@
+class AddDatabaseDatetimeToVisitorEntry < ActiveRecord::Migration[7.1]
+  def change
+    add_column :visitor_entries, :database_datetime, :datetime, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_22_025316) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_22_105115) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
     t.text "body"
@@ -204,6 +204,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_22_025316) do
     t.integer "unit_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "database_datetime", null: false
     t.index ["condo_id"], name: "index_visitor_entries_on_condo_id"
     t.index ["unit_id"], name: "index_visitor_entries_on_unit_id"
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -724,7 +724,7 @@ common_area20 = CommonArea.create!(
   rules: 'Acompanhamento de adulto obrigatório'
 )
 
-visitor_1 = Visitor.create!(
+Visitor.create!(
   condo: resident1.residence.condo,
   resident: resident1,
   visit_date: Time.zone.today,
@@ -732,7 +732,7 @@ visitor_1 = Visitor.create!(
   identity_number: '1456987',
   category: :visitor
 )
-visitor_2 = Visitor.create!(
+Visitor.create!(
   condo: resident1.residence.condo,
   resident: resident1,
   visit_date: Time.zone.today,
@@ -741,7 +741,7 @@ visitor_2 = Visitor.create!(
   category: :employee,
   recurrence: :working_days
 )
-visitor_3 = Visitor.create!(
+Visitor.create!(
   condo: resident2.residence.condo,
   resident: resident2,
   visit_date: Time.zone.today,
@@ -749,7 +749,7 @@ visitor_3 = Visitor.create!(
   identity_number: '3214567',
   category: :visitor
 )
-visitor_4 = Visitor.create!(
+Visitor.create!(
   condo: resident2.residence.condo,
   resident: resident2,
   visit_date: 1.day.from_now.to_date,
@@ -758,7 +758,7 @@ visitor_4 = Visitor.create!(
   category: :employee,
   recurrence: :monthly
 )
-visitor_5 = Visitor.create!(
+Visitor.create!(
   condo: resident3.residence.condo,
   resident: resident3,
   visit_date: 1.day.from_now.to_date,
@@ -767,7 +767,7 @@ visitor_5 = Visitor.create!(
   category: :employee,
   recurrence: :biweekly
 )
-visitor_6 = Visitor.create!(
+Visitor.create!(
   condo: resident3.residence.condo,
   resident: resident3,
   visit_date: Time.zone.today,
@@ -775,7 +775,7 @@ visitor_6 = Visitor.create!(
   identity_number: '6901234',
   category: :visitor
 )
-visitor_7 = Visitor.create!(
+Visitor.create!(
   condo: resident3.residence.condo,
   resident: resident3,
   visit_date: 2.days.from_now.to_date,
@@ -783,7 +783,7 @@ visitor_7 = Visitor.create!(
   identity_number: '7890123',
   category: :visitor
 )
-visitor_8 = Visitor.create!(
+Visitor.create!(
   condo: resident4.residence.condo,
   resident: resident4,
   visit_date: Time.zone.today,
@@ -792,7 +792,7 @@ visitor_8 = Visitor.create!(
   category: :employee,
   recurrence: :bimonthly
 )
-visitor_9 = Visitor.create!(
+Visitor.create!(
   condo: resident4.residence.condo,
   resident: resident4,
   visit_date: 1.day.from_now,
@@ -800,7 +800,7 @@ visitor_9 = Visitor.create!(
   identity_number: '9654321',
   category: :visitor
 )
-visitor_10 = Visitor.create!(
+Visitor.create!(
   condo: resident5.residence.condo,
   resident: resident5,
   visit_date: Time.zone.today,
@@ -810,62 +810,73 @@ visitor_10 = Visitor.create!(
   recurrence: :semiannual
 )
 
-visitor_entry1 = VisitorEntry.create!(
+VisitorEntry.create!(
   condo: condo1,
   full_name: 'Maria Fernandes',
   identity_number: '1234567',
-  unit: tower1.floors[0].units[0]
+  unit: tower1.floors[0].units[0],
+  database_datetime: 1.day.ago
 )
-visitor_entry2 = VisitorEntry.create!(
+VisitorEntry.create!(
   condo: condo1,
   full_name: 'João Pereira',
   identity_number: '2345678',
-  unit: tower1.floors[0].units[1]
+  unit: tower1.floors[0].units[1],
+  database_datetime: 3.days.ago.to_datetime
+
 )
-visitor_entry3 = VisitorEntry.create!(
+VisitorEntry.create!(
   condo: condo1,
   full_name: 'Ana Souza',
   identity_number: '3456789',
-  unit: tower1.floors[1].units[3]
+  unit: tower1.floors[1].units[3],
+  database_datetime: 14.days.ago.to_datetime
 )
-visitor_entry4 = VisitorEntry.create!(
+VisitorEntry.create!(
   condo: condo1,
   full_name: 'Carlos Lima',
-  identity_number: '4567890'
+  identity_number: '4567890',
+  database_datetime: 30.days.ago.to_datetime
 )
-visitor_entry5 = VisitorEntry.create!(
+VisitorEntry.create!(
   condo: condo1,
   full_name: 'Patricia Mendes',
-  identity_number: '5678901'
+  identity_number: '5678901',
+  database_datetime: 1.day.ago.to_datetime
 )
-visitor_entry6 = VisitorEntry.create!(
+VisitorEntry.create!(
   condo: condo1,
   full_name: 'Lucas Alves',
   identity_number: '6789012',
-  unit: tower1.floors[2].units[0]
+  unit: tower1.floors[2].units[0],
+  database_datetime: 2.days.ago.to_datetime
 )
-visitor_entry7 = VisitorEntry.create!(
+VisitorEntry.create!(
   condo: condo1,
   full_name: 'Mariana Costa',
   identity_number: '7890123',
-  unit: tower2.floors[2].units[0]
+  unit: tower2.floors[2].units[0],
+  database_datetime: 3.days.ago.to_datetime
 )
-visitor_entry8 = VisitorEntry.create!(
+VisitorEntry.create!(
   condo: condo1,
   full_name: 'Fernando Gomes',
   identity_number: '8901234',
-  unit: tower2.floors[0].units[0]
+  unit: tower2.floors[0].units[0],
+  database_datetime: 4.days.ago.to_datetime
 )
-visitor_entry9 = VisitorEntry.create!(
+VisitorEntry.create!(
   condo: condo2,
   full_name: 'Juliana Oliveira',
   identity_number: '9012345',
-  unit: tower3.floors[0].units[0]
+  unit: tower3.floors[0].units[0],
+  database_datetime: 1.days.ago.to_datetime
 )
-visitor_entry10 = VisitorEntry.create!(
+VisitorEntry.create!(
   condo: condo2,
   full_name: 'Gustavo Ferreira',
-  identity_number: '0123456'
+  identity_number: '0123456',
+  database_datetime: 1.days.ago.to_datetime
 )
 Announcement.create!(
   title: 'Reunião de condomínio',

--- a/spec/system/visitor/resident_sees_own_visitors_list_spec.rb
+++ b/spec/system/visitor/resident_sees_own_visitors_list_spec.rb
@@ -157,7 +157,7 @@ describe 'Resident sees own visitors list' do
     end
   end
 
-  context 'and searchs' do
+  context 'and searches' do
     it 'with visitor name filter' do
       resident = create :resident, :with_residence
       first_visitor = create :visitor, resident:, full_name: 'João Ferreira', identity_number: 145_364

--- a/spec/system/visitor_entry/manager_see_visitor_entries_spec.rb
+++ b/spec/system/visitor_entry/manager_see_visitor_entries_spec.rb
@@ -96,15 +96,15 @@ describe 'manager see visitor entries list' do
     it 'with visit date filter' do
       manager = create :manager
       condo = create :condo
-      travel_to '04/07/2024' do
+      travel_to Time.zone.local(2024, 7, 4, 22, 0) do
         create :visitor_entry, condo:, full_name: 'Nome Visitante Ontem'
       end
 
-      travel_to '05/07/2024' do
+      travel_to Time.zone.local(2024, 7, 5, 22, 1) do
         create :visitor_entry, condo:, full_name: 'Nome Primeiro Visitante'
       end
 
-      travel_to '05/07/2024 00:30' do
+      travel_to Time.zone.local(2024, 7, 5, 22, 2) do
         create :visitor_entry, condo:, full_name: 'Nome Último Visitante'
 
         login_as manager, scope: :manager
@@ -136,7 +136,7 @@ describe 'manager see visitor entries list' do
     end
 
     it 'with all filters' do
-      travel_to '05/07/2024' do
+      travel_to Time.zone.local(2024, 7, 5, 22, 1) do
         manager = create :manager
         condo = create :condo
         create :visitor_entry, condo:, full_name: 'Nome Primeiro Visitante', identity_number: '145697'


### PR DESCRIPTION
### Introdução 
Graças ao CI do github foi notado a necessidade de tratar as querys com data quando um registro é criado entre as 21 e 00, oque gerava um erro devido ao Timezone e a consulta ao banco da dados retornava dados incorretos

Foi deixado os dois testes de sistema relacionados a essa pesquisa com travel_to com horario fixo das 22h. Para assim garantir que o erro nao aconteça

### Objetivo
Garantir que uma pesquisa ao banco de dados relacionado a uma entrada de visitante retorne os dados corretamente.


### Soluçao
Como o problema existia no fato do banco de dados ser salvo em UTC e a pesquisa informar uma data BRT, foi necessario criar um registro no banco de dados que salva a data em BRT para que ele seja utlizado na hora da pesquisa